### PR TITLE
feat(issue-35): add immutable policy-engine audit trail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1977,6 +1977,10 @@
       "resolved": "packages/schemas",
       "link": true
     },
+    "node_modules/@neurologix/security-core": {
+      "resolved": "packages/security-core",
+      "link": true
+    },
     "node_modules/@neurologix/ui": {
       "resolved": "packages/ui",
       "link": true
@@ -2494,6 +2498,13 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3803,6 +3814,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "license": "ISC"
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -11321,6 +11339,235 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/security-core": {
+      "name": "@neurologix/security-core",
+      "version": "0.1.0",
+      "dependencies": {
+        "crypto": "^1.0.1"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "eslint": "^8.50.0",
+        "typescript": "^5.3.0",
+        "vitest": "^3.2.0"
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "packages/security-core/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "packages/security-core/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/ui": {
       "name": "@neurologix/ui",
       "version": "0.1.0",
@@ -11427,6 +11674,7 @@
       "dependencies": {
         "@neurologix/core": "*",
         "@neurologix/schemas": "*",
+        "@neurologix/security-core": "*",
         "zod": "^3.23.8"
       },
       "devDependencies": {

--- a/packages/security-core/src/audit-logger.ts
+++ b/packages/security-core/src/audit-logger.ts
@@ -4,16 +4,22 @@
  */
 
 import crypto from 'crypto';
-import { AuditEvent, ServiceIdentity } from './security-types';
+import {
+  AuditChainEntry,
+  AuditEvent,
+  AuditIntegrityReport,
+  AuditLogCheckpoint,
+  AuditQueryCriteria,
+  ServiceIdentity,
+} from './security-types';
 
 /**
  * Audit logger for tracking security and compliance events
  * Uses hash chain for immutability verification
  */
 export class AuditLogger {
-  private events: AuditEvent[] = [];
-  private eventHashes: string[] = [];
-  private lastHash: string = '';
+  private chainEntries: AuditChainEntry[] = [];
+  private lastHash: string | null = null;
 
   /**
    * Log an audit event with immutability verification
@@ -34,12 +40,14 @@ export class AuditLogger {
       immutable: true,
     };
 
-    // Store event
-    this.events.push(fullEvent);
-
-    // Calculate hash for immutability chain
-    const hash = this.calculateEventHash(fullEvent, this.lastHash);
-    this.eventHashes.push(hash);
+    const previousHash = this.lastHash;
+    const hash = this.calculateEventHash(fullEvent, previousHash);
+    this.chainEntries.push({
+      sequence: this.chainEntries.length + 1,
+      event: fullEvent,
+      previousHash,
+      hash,
+    });
     this.lastHash = hash;
 
     return { eventId, hash };
@@ -133,33 +141,21 @@ export class AuditLogger {
    * @returns Whether hash chain is intact and immutable
    */
   verifyImmutability(): boolean {
-    let expectedHash = '';
-
-    for (let i = 0; i < this.events.length; i++) {
-      const event = this.events[i];
-      const calculatedHash = this.calculateEventHash(event, expectedHash);
-
-      if (calculatedHash !== this.eventHashes[i]) {
-        return false;
-      }
-
-      expectedHash = calculatedHash;
-    }
-
-    return expectedHash === this.lastHash;
+    return this.getIntegrityReport().valid;
   }
 
   /**
    * Query events by criteria
    */
-  queryEvents(criteria: {
-    eventType?: string;
-    serviceId?: string;
-    outcome?: string;
-    startDate?: Date;
-    endDate?: Date;
-  }): AuditEvent[] {
-    return this.events.filter((event) => {
+  queryEvents(criteria: AuditQueryCriteria): AuditEvent[] {
+    return this.queryEntries(criteria).map((entry) => entry.event);
+  }
+
+  /**
+   * Query full immutable chain entries by criteria
+   */
+  queryEntries(criteria: AuditQueryCriteria): AuditChainEntry[] {
+    return this.chainEntries.filter(({ event }) => {
       if (criteria.eventType && event.eventType !== criteria.eventType) return false;
       if (criteria.serviceId && event.service.serviceId !== criteria.serviceId) return false;
       if (criteria.outcome && event.outcome !== criteria.outcome) return false;
@@ -173,14 +169,21 @@ export class AuditLogger {
    * Get all events
    */
   getAllEvents(): AuditEvent[] {
-    return [...this.events];
+    return this.chainEntries.map((entry) => entry.event);
+  }
+
+  /**
+   * Get all immutable chain entries
+   */
+  getChainEntries(): AuditChainEntry[] {
+    return [...this.chainEntries];
   }
 
   /**
    * Get event count
    */
   getEventCount(): number {
-    return this.events.length;
+    return this.chainEntries.length;
   }
 
   /**
@@ -198,9 +201,75 @@ export class AuditLogger {
   }
 
   /**
+   * Produce an integrity report for the current chain
+   */
+  getIntegrityReport(): AuditIntegrityReport {
+    let expectedPreviousHash: string | null = null;
+    let lastVerifiedHash: string | null = null;
+
+    for (const entry of this.chainEntries) {
+      if (entry.previousHash !== expectedPreviousHash) {
+        return {
+          valid: false,
+          checkedEvents: entry.sequence,
+          lastVerifiedHash,
+          firstInvalidSequence: entry.sequence,
+          expectedHash: expectedPreviousHash ?? undefined,
+          actualHash: entry.previousHash ?? undefined,
+        };
+      }
+
+      const calculatedHash = this.calculateEventHash(entry.event, expectedPreviousHash);
+      if (calculatedHash !== entry.hash) {
+        return {
+          valid: false,
+          checkedEvents: entry.sequence,
+          lastVerifiedHash,
+          firstInvalidSequence: entry.sequence,
+          expectedHash: calculatedHash,
+          actualHash: entry.hash,
+        };
+      }
+
+      lastVerifiedHash = calculatedHash;
+      expectedPreviousHash = calculatedHash;
+    }
+
+    return {
+      valid: lastVerifiedHash === this.lastHash,
+      checkedEvents: this.chainEntries.length,
+      lastVerifiedHash,
+      ...(lastVerifiedHash === this.lastHash
+        ? {}
+        : {
+            firstInvalidSequence: this.chainEntries.length,
+            expectedHash: lastVerifiedHash ?? undefined,
+            actualHash: this.lastHash ?? undefined,
+          }),
+    };
+  }
+
+  /**
+   * Get the latest persisted checkpoint in the hash chain
+   */
+  getLatestCheckpoint(): AuditLogCheckpoint | null {
+    const latestEntry = this.chainEntries.at(-1);
+    if (!latestEntry) {
+      return null;
+    }
+
+    return {
+      sequence: latestEntry.sequence,
+      eventId: latestEntry.event.eventId,
+      hash: latestEntry.hash,
+      timestamp: latestEntry.event.timestamp,
+    };
+  }
+
+  /**
    * Calculate hash for an event (immutability chain)
    */
-  private calculateEventHash(event: AuditEvent, previousHash: string): string {
+  private calculateEventHash(event: AuditEvent, previousHash: string | null): string {
     const eventString = JSON.stringify({
       eventId: event.eventId,
       eventType: event.eventType,
@@ -209,7 +278,7 @@ export class AuditLogger {
       timestamp: event.timestamp.toISOString(),
     });
 
-    const content = `${previousHash}:${eventString}`;
+    const content = `${previousHash ?? 'GENESIS'}:${eventString}`;
     return crypto.createHash('sha256').update(content).digest('hex');
   }
 

--- a/packages/security-core/src/certificate-manager.ts
+++ b/packages/security-core/src/certificate-manager.ts
@@ -154,9 +154,10 @@ export class CertificateManager {
    * Parse certificate issuance and expiration dates (placeholder)
    * In production, would use a proper certificate parsing library
    */
-  private parseCertificateDates(_certPem: string): { issuedAt: Date; expiresAt: Date } {
+  private parseCertificateDates(certPem: string): { issuedAt: Date; expiresAt: Date } {
     // Placeholder: In production, parse with crypto.X509Certificate or similar
     // For now, return predictable test values
+    void certPem;
     const issuedAt = new Date();
     const expiresAt = new Date(issuedAt.getTime() + 365 * 24 * 60 * 60 * 1000); // 1 year
 

--- a/packages/security-core/src/security-core.test.ts
+++ b/packages/security-core/src/security-core.test.ts
@@ -132,8 +132,8 @@ describe('CertificateManager', () => {
 
   it('should track certificate rotation', () => {
     const serviceid = 'policy-engine';
-    const cert1 = '-----BEGIN CERTIFICATE-----\nMIIC1\n-----END CERTIFICATE-----';
-    const cert2 = '-----BEGIN CERTIFICATE-----\nMIIC2\n-----END CERTIFICATE-----';
+    const cert1 = '-----BEGIN CERTIFICATE-----\nQUJDRA==\n-----END CERTIFICATE-----';
+    const cert2 = '-----BEGIN CERTIFICATE-----\nRUZHSA==\n-----END CERTIFICATE-----';
 
     manager.loadCertificate(serviceid, cert1);
     const status = manager.rotateCertificate(serviceid, cert2);
@@ -209,6 +209,23 @@ describe('AuditLogger', () => {
     expect(logger.getEventCount()).toBe(3);
   });
 
+  it('should expose integrity reports and checkpoints for evidence capture', () => {
+    const service: ServiceIdentity = { serviceId: 'policy-engine' };
+
+    logger.logAuthSuccess(service);
+    logger.logPolicyEnforced(service, 'require-mTLS', true);
+
+    const integrity = logger.getIntegrityReport();
+    const checkpoint = logger.getLatestCheckpoint();
+
+    expect(integrity.valid).toBe(true);
+    expect(integrity.checkedEvents).toBe(2);
+    expect(integrity.lastVerifiedHash).toBeTruthy();
+    expect(checkpoint).not.toBeNull();
+    expect(checkpoint?.sequence).toBe(2);
+    expect(checkpoint?.hash).toBeTruthy();
+  });
+
   it('should query events by criteria', () => {
     const service1: ServiceIdentity = { serviceId: 'policy-engine' };
     const service2: ServiceIdentity = { serviceId: 'core-adapter' };
@@ -222,6 +239,20 @@ describe('AuditLogger', () => {
 
     const failures = logger.queryEvents({ outcome: 'FAILURE' });
     expect(failures.length).toBe(1);
+  });
+
+  it('should query immutable chain entries with sequence metadata', () => {
+    const service: ServiceIdentity = { serviceId: 'policy-engine' };
+
+    logger.logAuthSuccess(service);
+    logger.logAuthFailure(service, undefined, 'Rejected mTLS client cert');
+
+    const entries = logger.queryEntries({ serviceId: 'policy-engine' });
+
+    expect(entries.length).toBe(2);
+    expect(entries[0].sequence).toBe(1);
+    expect(entries[1].sequence).toBe(2);
+    expect(entries[1].previousHash).toBe(entries[0].hash);
   });
 
   it('should track policy blocked events', () => {

--- a/packages/security-core/src/security-types.ts
+++ b/packages/security-core/src/security-types.ts
@@ -90,6 +90,68 @@ export interface AuditEvent {
 }
 
 /**
+ * Query criteria for audit event retrieval
+ */
+export interface AuditQueryCriteria {
+  /** Filter by event type */
+  eventType?: string;
+  /** Filter by originating service */
+  serviceId?: string;
+  /** Filter by event outcome */
+  outcome?: AuditEvent['outcome'];
+  /** Filter by inclusive start timestamp */
+  startDate?: Date;
+  /** Filter by inclusive end timestamp */
+  endDate?: Date;
+}
+
+/**
+ * One immutable audit chain entry with hash linkage metadata
+ */
+export interface AuditChainEntry {
+  /** Monotonic sequence number in the chain */
+  sequence: number;
+  /** Stored audit event */
+  event: AuditEvent;
+  /** Previous chain hash, or null for genesis entry */
+  previousHash: string | null;
+  /** Current entry hash */
+  hash: string;
+}
+
+/**
+ * Integrity verification report for the current audit chain
+ */
+export interface AuditIntegrityReport {
+  /** Whether the full chain verified successfully */
+  valid: boolean;
+  /** Number of events checked during verification */
+  checkedEvents: number;
+  /** Last hash confirmed during verification */
+  lastVerifiedHash: string | null;
+  /** First invalid sequence number if corruption is detected */
+  firstInvalidSequence?: number;
+  /** Expected hash when corruption is detected */
+  expectedHash?: string;
+  /** Actual stored hash when corruption is detected */
+  actualHash?: string;
+}
+
+/**
+ * Latest immutable checkpoint for external persistence or evidence capture
+ */
+export interface AuditLogCheckpoint {
+  /** Chain sequence number */
+  sequence: number;
+  /** Event identifier at the checkpoint */
+  eventId: string;
+  /** Checkpoint hash */
+  hash: string;
+  /** Checkpoint timestamp */
+  timestamp: Date;
+}
+
+/**
  * Service authentication policy configuration
  */
 export interface AuthenticationPolicy {

--- a/packages/security-core/tsconfig.json
+++ b/packages/security-core/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/planning/builder-handoff-issue-35.md
+++ b/planning/builder-handoff-issue-35.md
@@ -1,0 +1,46 @@
+# Builder Handoff Record
+
+- Work Item: Issue#35
+- Branch: issue-35-policy-engine-audit-trail
+- PR: #59
+- Lane: standard
+- Risk Score: 3
+- Completion Claim Level: ready for validation
+
+## Slices Completed
+
+- Slice: `@neurologix/security-core` now emits immutable audit chain entries with sequence metadata, integrity reports, and evidence checkpoints.
+- Slice: `@neurologix/policy-engine` now records immutable audit events for policy creation, updates, deletion, evaluations, emergency overrides, and policy violations.
+- Slice: `PolicyEngineService` now exposes validator-consumable audit retrieval and hash-chain verification APIs.
+- Slice: Workspace dependency graph and lockfile were refreshed to link `@neurologix/security-core` into `@neurologix/policy-engine`.
+
+## Files Changed
+
+- `package-lock.json`
+- `packages/security-core/src/audit-logger.ts`
+- `packages/security-core/src/certificate-manager.ts`
+- `packages/security-core/src/security-core.test.ts`
+- `packages/security-core/src/security-types.ts`
+- `packages/security-core/tsconfig.json`
+- `services/policy-engine/package.json`
+- `services/policy-engine/src/services/policy-engine.service.test.ts`
+- `services/policy-engine/src/services/policy-engine.service.ts`
+- `services/policy-engine/tsconfig.json`
+
+## Validation Summary
+
+- Focused validation:
+  - `npm exec --workspace @neurologix/security-core -- vitest run --config vitest.config.ts`
+  - `npm --workspace @neurologix/security-core run build`
+  - `npm --workspace @neurologix/policy-engine test`
+  - `npm --workspace @neurologix/policy-engine run build`
+- Repository validation:
+  - `npm run lint`
+  - `npm test`
+  - `npm run build`
+
+## Risk and Rollback
+
+- Risk: Additional consumers may later need the same immutable audit abstraction.
+- Mitigation: Changes remain isolated to `security-core`, `policy-engine`, and lockfile wiring.
+- Rollback: Revert the bounded Issue #35 changeset.

--- a/planning/handoff-to-validator-issue-35.md
+++ b/planning/handoff-to-validator-issue-35.md
@@ -1,0 +1,70 @@
+[Context]
+Work Item: Issue#35
+Chain Step: 23
+Target Agent: Validator-Merger
+Source: Issue#35
+Status: ready-for-validation
+
+Objective
+Validate the bounded Phase 7 runtime slice that adds immutable, queryable audit evidence to `@neurologix/security-core` and `@neurologix/policy-engine`.
+
+Required Actions
+1. Validate scope remains limited to the ten files listed in `planning/validation-evidence-issue-35.md`.
+2. Inspect immutable audit-chain enhancements in:
+   - `packages/security-core/src/security-types.ts`
+   - `packages/security-core/src/audit-logger.ts`
+   - `packages/security-core/src/security-core.test.ts`
+3. Inspect policy-engine integration and exposed audit APIs in:
+   - `services/policy-engine/src/services/policy-engine.service.ts`
+   - `services/policy-engine/src/services/policy-engine.service.test.ts`
+4. Re-run required checks:
+   - `npm run lint`
+   - `npm test`
+   - `npm run build`
+5. Confirm validator evidence supports these behaviors:
+   - privileged policy mutations emit immutable audit entries,
+   - blocked evaluations and policy violations are queryable,
+   - audit-chain integrity verification is deterministic.
+6. Confirm the ESM compatibility adjustment in `packages/security-core/tsconfig.json` is bounded to workspace package interoperability.
+
+Forbidden Actions
+- Do not widen scope into full-service mTLS rollout, secrets scanning, or unrelated Phase 8/9 work.
+- Do not modify `.github/` framework internals during this normal issue execution.
+- Do not merge with failing required checks.
+
+Files to Inspect
+- `planning/issue-selection-issue-35.md`
+- `planning/builder-handoff-issue-35.md`
+- `planning/validation-evidence-issue-35.md`
+- `package-lock.json`
+- `packages/security-core/src/audit-logger.ts`
+- `packages/security-core/src/certificate-manager.ts`
+- `packages/security-core/src/security-core.test.ts`
+- `packages/security-core/src/security-types.ts`
+- `packages/security-core/tsconfig.json`
+- `services/policy-engine/package.json`
+- `services/policy-engine/src/services/policy-engine.service.ts`
+- `services/policy-engine/src/services/policy-engine.service.test.ts`
+- `services/policy-engine/tsconfig.json`
+- Issue: https://github.com/Coding-Krakken/NeuroLogix/issues/35
+
+Acceptance Criteria
+1. Immutable audit chain entries, integrity reports, and checkpoints are available from `@neurologix/security-core`.
+2. `PolicyEngineService` exposes queryable immutable audit evidence for privileged mutations and blocked/denied policy flows.
+3. Workspace validation (`lint`, `test`, `build`) passes with no new errors.
+4. Scope remains bounded, reversible, and traceable to Issue #35.
+
+Required GitHub Updates
+1. Post validator review summary with acceptance mapping and command outcomes.
+2. Record validator decision and merge disposition in the PR and Issue #35.
+3. If merged, publish post-merge validation and closure linkage.
+
+Validation Expectations
+- Treat immutable audit-chain integrity as a primary correctness criterion.
+- Accept existing warnings-only lint baseline outside the changed slice; reject new errors.
+- Verify rollback remains a simple revert of the bounded Issue #35 changeset.
+
+Final Command Requirement
+```bash
+.\.utils\dispatch-code-chat.ps1 -Mode ask -TargetAgent "validator-merger" -PromptFile "planning/handoff-to-validator-issue-35.md" -AddFile ".github/templates/pr-summary.md,.github/templates/review-summary.md,planning/validation-evidence-issue-35.md"
+```

--- a/planning/issue-selection-issue-35.md
+++ b/planning/issue-selection-issue-35.md
@@ -1,0 +1,92 @@
+# Issue Selection Record — Issue #35
+
+Date: 2026-03-10
+Agent Mode: `planner-architect`
+Repository: `Coding-Krakken/NeuroLogix`
+Source Handoff: `planning/handoff-to-planner-issue-49.md`
+
+## Baseline Context
+
+- Issue #49 policy clarification merged and remains the active lane-selection baseline for model/evidence-only slices.
+- Issue #34 Phase 6 Mission Control UI is merged (`PR #56`).
+- Issue #57 Phase 7 security foundation is merged (`PR #58`) and provides the new `@neurologix/security-core` workspace package.
+- The next eligible runtime delivery work is expected to continue Issue #35 from the newly merged security foundation.
+
+## Candidate Collection
+
+Live open issues refresh (`gh issue list --state open`):
+- `#46`, `#35`, `#37`, `#45`, `#36`
+
+## Eligibility Gates
+
+| Issue | Blocked Status | Dependencies Resolved / Safe First | Implementable Confidence | PR Guardrails Fit | Safety/Compliance Constraints | Eligibility | Notes |
+|---|---|---|---|---|---|---|---|
+| #35 | PASS | PASS | PASS | PASS | PASS | **Eligible** | Dependencies `#34` and `#44` are resolved; bounded runtime slice can build directly on `@neurologix/security-core`. |
+| #36 | PASS | FAIL | PASS | PASS | PASS | Ineligible | Blocked by unresolved dependency `#35`. |
+| #37 | PASS | FAIL | PASS | PASS | PASS | Ineligible | Blocked by unresolved dependencies `#35`, `#36`, and `#46`. |
+| #45 | PASS | PASS | PASS | PASS | FAIL | Ineligible | Deliverables remain under `.github/.system-state/**`, disallowed in the normal execution lane. |
+| #46 | PASS | FAIL | PASS | PASS | FAIL | Ineligible | Depends on unresolved `#45`; deliverables remain under `.github/.system-state/**`. |
+
+## Weighted Scoring (Eligible Set)
+
+Scoring model (normalized weights):
+- business_value: 0.30
+- urgency: 0.15
+- risk_reduction_or_opportunity_enablement: 0.15
+- dependency_unlocking_power: 0.10
+- strategic_alignment: 0.10
+- implementation_confidence: 0.10
+- size_efficiency: 0.05
+- testability: 0.03
+- observability_readiness: 0.02
+
+| Issue | BV | U | RR/OE | DUP | SA | IC | SE | T | OR | Weighted Total |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| #35 | 0.92 | 0.88 | 0.91 | 0.83 | 0.90 | 0.89 | 0.84 | 0.87 | 0.85 | **0.888** |
+
+Tie-breakers not required (single eligible issue).
+
+## Selection Decision
+
+Selected issue: **#35 — Phase 7 Delivery: Security and Compliance Hardening**
+
+Rationale:
+1. It is the highest-value fully eligible issue after deterministic gating.
+2. It directly extends the newly merged Phase 7 security foundation with concrete runtime hardening.
+3. A bounded slice can deliver queryable immutable audit evidence for privileged and safety-critical policy-engine actions without widening scope.
+4. The slice is small, reviewable, reversible, and improves readiness for later control-verification work.
+
+## Smallest Safe Vertical Slice (Implemented)
+
+In scope:
+1. Extend `@neurologix/security-core` audit primitives with chain-entry metadata, integrity reports, and evidence checkpoints.
+2. Integrate the `policy-engine` service with immutable audit recording for policy create/update/delete/evaluate/violation paths.
+3. Expose query and integrity APIs from `PolicyEngineService` for validator-consumable evidence.
+4. Add focused tests covering privileged mutations, blocked evaluations, and audit disablement behavior.
+5. Refresh the workspace lockfile after wiring the new workspace dependency.
+
+Out of scope:
+- Fleet-wide mTLS rollout across every service.
+- Secrets scanning pipeline changes.
+- `.github/` model or workflow changes.
+- Phase 8/9 runtime delivery.
+- Unrelated service refactors.
+
+## Risks and Rollback
+
+Primary risks:
+- Module-format mismatch between workspace packages could break runtime imports.
+- Audit logging changes could widen into unrelated service behavior.
+
+Mitigations:
+- Keep the runtime slice isolated to `security-core`, `policy-engine`, and lockfile wiring.
+- Validate both focused workspace commands and repository-level `lint`, `test`, and `build`.
+
+Rollback:
+- Revert the Issue #35 bounded slice commit to restore prior `security-core` and `policy-engine` behavior.
+
+## Required GitHub Traceability Updates
+
+- Comment on Issue `#35` with the bounded slice plan and file targets.
+- Open a PR linked to Issue `#35` after commit/push.
+- Hand off to Validator-Merger with validation evidence and bounded rollback notes.

--- a/planning/state/current-cycle.md
+++ b/planning/state/current-cycle.md
@@ -1,50 +1,51 @@
 # Current Cycle State
 
-- Timestamp: 2026-03-10T14:12:00Z
-- Current Issue: Issue#44
-- Current Branch: issue-44-security-resilience-baseline
-- PR State: open-revalidation-ready (#48)
+- Timestamp: 2026-03-10T20:50:00Z
+- Current Issue: Issue#35
+- Current Branch: issue-35-policy-engine-audit-trail
+- PR State: open (#59)
 - Lane: standard
 - Risk Score: 3
 
 ## Latest Artifacts
 
-- Builder Handoff: planning/builder-handoff-issue-44.md
-- Validator Handoff: planning/handoff-to-validator-issue-44.md
-- Validation Evidence: planning/validation-evidence-issue-44.md
-- Efficiency Gate: planning/efficiency-gate-summary-issue-44.json
-- Evidence JSON: planning/evidence-issue-44.json
+- Issue Selection: planning/issue-selection-issue-35.md
+- Builder Handoff: planning/builder-handoff-issue-35.md
+- Validator Handoff: planning/handoff-to-validator-issue-35.md
+- Validation Evidence: planning/validation-evidence-issue-35.md
 
 ## Active Blockers
 
-- Standard-lane efficiency gate mismatch for bounded model/evidence slice (`docToCodeRatio: Infinity`, preferred line threshold warning promoted to fail for standard lane).
+- None for the bounded slice. Remaining epic scope is intentionally deferred to later Issue #35 slices.
 
-## Planned Blocker Closure Actions
+## Planned Completion Actions
 
-1. Complete validator review against PR #48.
-2. Confirm whether strict-lane efficiency artifact is acceptable for model/evidence-only bounded rework.
-3. Merge or route follow-up policy clarification issue.
+1. Post Issue #35 implementation-start traceability comment.
+2. Commit and push the bounded audit-trail slice branch.
+3. Open the linked PR and hand off to Validator-Merger.
 
-## Bounded File Scope for Rework
+## Bounded File Scope
 
-- .github/.system-state/security/security_model.yaml
-- .github/.system-state/resilience/resilience_model.yaml
-- planning/validation-evidence-issue-44.md
-- planning/efficiency-gate-summary-issue-44.json
-- planning/evidence-issue-44.json
-- planning/builder-handoff-issue-44.md
-- planning/handoff-to-validator-issue-44.md
-- planning/state/current-cycle.md
+- package-lock.json
+- packages/security-core/src/audit-logger.ts
+- packages/security-core/src/certificate-manager.ts
+- packages/security-core/src/security-core.test.ts
+- packages/security-core/src/security-types.ts
+- packages/security-core/tsconfig.json
+- services/policy-engine/package.json
+- services/policy-engine/src/services/policy-engine.service.ts
+- services/policy-engine/src/services/policy-engine.service.test.ts
+- services/policy-engine/tsconfig.json
 
 ## Validation Requirements
 
-- Lane checks: lint, unit, integration, build
-- Efficiency gate artifact updated (strict-lane pass; standard-lane mismatch documented)
-- Evidence JSON must include available PR checks context and non-zero bounded diff
+- Required checks: `npm run lint`, `npm test`, `npm run build`
+- Focused workspace checks for `@neurologix/security-core` and `@neurologix/policy-engine`
+- Immutable audit-chain integrity verified through tests and exposed service APIs
 
 ## Important Architectural Decisions
 
-- Decision: Keep Issue #44 model content fixed and execute bounded rework only on merge-gate preconditions.
-- Rationale: PR/open-check context and non-zero bounded diff were required for validator re-entry.
-- Scope impact: Limited to the eight rework artifacts listed above.
-- Follow-up required: yes (validator confirmation on efficiency-lane policy handling).
+- Decision: Extend the merged `@neurologix/security-core` foundation instead of creating a second audit abstraction.
+- Rationale: A single reusable immutable audit primitive reduces entropy and keeps Issue #35 bounded to one critical service integration.
+- Scope impact: Constrained to `security-core`, `policy-engine`, and workspace dependency wiring.
+- Follow-up required: yes (later Issue #35 slices for broader service rollout, secrets management, and compliance verification matrix).

--- a/planning/validation-evidence-issue-35.md
+++ b/planning/validation-evidence-issue-35.md
@@ -1,0 +1,69 @@
+# Validation Evidence — Issue #35
+
+Date: 2026-03-10  
+Branch: `issue-35-policy-engine-audit-trail`  
+PR: `#59`  
+Work Item: `#35`
+
+## Bounded Scope
+
+- `package-lock.json`
+- `packages/security-core/src/audit-logger.ts`
+- `packages/security-core/src/certificate-manager.ts`
+- `packages/security-core/src/security-core.test.ts`
+- `packages/security-core/src/security-types.ts`
+- `packages/security-core/tsconfig.json`
+- `services/policy-engine/package.json`
+- `services/policy-engine/src/services/policy-engine.service.test.ts`
+- `services/policy-engine/src/services/policy-engine.service.ts`
+- `services/policy-engine/tsconfig.json`
+
+## Validation Commands
+
+| Command | Result |
+|---|---|
+| `npm exec --workspace @neurologix/security-core -- vitest run --config vitest.config.ts` | PASS |
+| `npm --workspace @neurologix/security-core run build` | PASS |
+| `npm --workspace @neurologix/policy-engine test` | PASS |
+| `npm --workspace @neurologix/policy-engine run build` | PASS |
+| `npm run lint` | PASS (warnings-only baseline in other packages; no new errors) |
+| `npm test` | PASS |
+| `npm run build` | PASS |
+
+## Guardrail Metrics
+
+- `changedFiles`: `10`
+- `additions`: `664`
+- `deletions`: `71`
+- Preferred guardrail check (`<=25 files`, `<=600 lines changed`): WARNING — line count above preferred threshold but within warning threshold and still bounded to one runtime slice.
+
+## Slice Acceptance Mapping
+
+1. Privileged policy mutations emit immutable audit entries with chain metadata — PASS.
+2. Policy evaluation denials and violations are queryable from `PolicyEngineService` — PASS.
+3. Audit hash-chain integrity can be verified deterministically for validator evidence — PASS.
+4. Audit disablement remains explicit and non-recording when configured off — PASS.
+
+## Decision Evidence
+
+- `AuditLogger` now exposes chain-entry queries, integrity reports, and latest checkpoints suitable for evidence capture.
+- `PolicyEngineService` now records immutable events for `POLICY_CREATE`, `POLICY_UPDATE`, `POLICY_DELETE`, `POLICY_EVALUATION`, `POLICY_EVALUATION_ERROR`, and `POLICY_VIOLATION`.
+- The policy-engine test suite now covers privileged mutation auditing, blocked evaluation retrieval, and audit disablement behavior.
+- `security-core` now builds as ESM to keep the workspace package import compatible with policy-engine tests and builds.
+
+## Risks and Rollback
+
+- Risk: Additional runtime services will still need audit integration in later Issue #35 slices.
+- Mitigation: This slice confines changes to a reusable package plus one critical service boundary.
+- Rollback: Revert the bounded Issue #35 commit to remove the immutable audit integration and restore prior behavior.
+
+## GitHub Traceability
+
+- Issue #35 implementation-start comment:
+	- https://github.com/Coding-Krakken/NeuroLogix/issues/35#issuecomment-4034025607
+- Issue #35 PR/check-status update comment:
+	- https://github.com/Coding-Krakken/NeuroLogix/issues/35#issuecomment-4034032142
+- PR risk note:
+	- https://github.com/Coding-Krakken/NeuroLogix/pull/59#issuecomment-4034033100
+- PR link:
+	- https://github.com/Coding-Krakken/NeuroLogix/pull/59

--- a/services/policy-engine/package.json
+++ b/services/policy-engine/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@neurologix/core": "*",
+    "@neurologix/security-core": "*",
     "@neurologix/schemas": "*",
     "zod": "^3.23.8"
   },

--- a/services/policy-engine/src/services/policy-engine.service.test.ts
+++ b/services/policy-engine/src/services/policy-engine.service.test.ts
@@ -527,4 +527,79 @@ describe('PolicyEngineService', () => {
       ).toBe(stats.evaluationsLast24h);
     });
   });
+
+  describe('Security audit trail', () => {
+    it('should record immutable audit events for privileged policy mutations', async () => {
+      const policy = await service.createPolicy({
+        name: 'Audit Managed Policy',
+        version: '1.0.0',
+        category: 'security',
+        priority: 'high',
+        status: 'active',
+        regoRules: 'package audit.managed\ndefault allow = true',
+        metadata: { author: 'security-team' },
+      });
+
+      await service.updatePolicy(policy.id, { description: 'Updated by audit test' });
+      await service.deletePolicy(policy.id);
+
+      const auditTrail = service.getSecurityAuditTrail();
+      const eventTypes = auditTrail.map((entry) => entry.event.eventType);
+
+      expect(eventTypes).toContain('POLICY_CREATE');
+      expect(eventTypes).toContain('POLICY_UPDATE');
+      expect(eventTypes).toContain('POLICY_DELETE');
+      expect(service.verifySecurityAuditTrail().valid).toBe(true);
+    });
+
+    it('should expose queryable blocked evaluations and linked violations', async () => {
+      const request: PolicyEvaluationRequest = {
+        requestId: '550e8400-e29b-41d4-a716-446655440010',
+        action: 'recipe.execute',
+        resource: 'conveyor/line-2',
+        context: {
+          plc_interlocks: [{ name: 'light_curtain', active: true }],
+        },
+        subject: {
+          userId: 'operator-audit',
+          roles: ['operator'],
+          permissions: ['recipe.execute'],
+        },
+        timestamp: new Date(),
+      };
+
+      const result = await service.evaluateRequest(request);
+      const blockedEvaluations = service.getSecurityAuditTrail({
+        eventType: 'POLICY_EVALUATION',
+        outcome: 'BLOCKED',
+      });
+      const violations = service.getSecurityAuditTrail({ eventType: 'POLICY_VIOLATION' });
+
+      expect(result.decision).toBe('deny');
+      expect(blockedEvaluations.length).toBeGreaterThan(0);
+      expect(blockedEvaluations[0].event.metadata?.decision).toBe('deny');
+      expect(violations.length).toBeGreaterThan(0);
+      expect(violations[0].event.metadata?.policyName).toBeDefined();
+    });
+
+    it('should honor audit disablement without recording immutable entries', async () => {
+      const noAuditService = new PolicyEngineService({
+        ...mockConfig,
+        auditEnabled: false,
+      });
+
+      await noAuditService.createPolicy({
+        name: 'No Audit Policy',
+        version: '1.0.0',
+        category: 'quality',
+        priority: 'low',
+        status: 'active',
+        regoRules: 'package audit.disabled\ndefault allow = true',
+        metadata: { author: 'test-user' },
+      });
+
+      expect(noAuditService.getSecurityAuditTrail()).toHaveLength(0);
+      expect(noAuditService.verifySecurityAuditTrail().valid).toBe(true);
+    });
+  });
 });

--- a/services/policy-engine/src/services/policy-engine.service.ts
+++ b/services/policy-engine/src/services/policy-engine.service.ts
@@ -27,6 +27,14 @@ import {
   generateId,
   logAuditEvent,
 } from '@neurologix/core';
+import {
+  createAuditLogger,
+  type AuditChainEntry,
+  type AuditEvent,
+  type AuditIntegrityReport,
+  type AuditQueryCriteria,
+  type ServiceIdentity,
+} from '@neurologix/security-core';
 import logger from '@neurologix/core/logger';
 import { z } from 'zod';
 
@@ -53,6 +61,8 @@ export class PolicyEngineService {
   private evaluationCache: Map<string, { result: PolicyEvaluationResult; expiresAt: Date }> =
     new Map();
   private config: PolicyEngineConfig;
+  private readonly securityAuditLogger = createAuditLogger();
+  private readonly serviceIdentity: ServiceIdentity = { serviceId: 'policy-engine' };
   private evaluationMetrics: {
     evaluationsLast24h: number;
     decisionsLast24h: { allow: number; deny: number; approval_required: number };
@@ -101,16 +111,19 @@ export class PolicyEngineService {
 
       this.policies.set(policy.id, policy);
 
-      logAuditEvent({
+      this.recordSecurityAudit({
+        eventType: 'POLICY_CREATE',
         action: 'policy_create',
         resource: `policy/${policy.id}`,
-        outcome: 'success',
-        details: {
+        outcome: 'SUCCESS',
+        description: `Policy ${policy.name} created in policy-engine`,
+        severity: 'medium',
+        metadata: {
+          policyId: policy.id,
           policyName: policy.name,
           category: policy.category,
           priority: policy.priority,
         },
-        severity: 'medium',
       });
 
       return policy;
@@ -151,15 +164,18 @@ export class PolicyEngineService {
       // Clear related cache entries
       this.clearPolicyCache(policyId);
 
-      logAuditEvent({
+      this.recordSecurityAudit({
+        eventType: 'POLICY_UPDATE',
         action: 'policy_update',
         resource: `policy/${policyId}`,
-        outcome: 'success',
-        details: {
+        outcome: 'SUCCESS',
+        description: `Policy ${updatedPolicy.name} updated in policy-engine`,
+        severity: 'medium',
+        metadata: {
+          policyId,
           policyName: updatedPolicy.name,
           changes: Object.keys(updates),
         },
-        severity: 'medium',
       });
 
       return updatedPolicy;
@@ -196,12 +212,14 @@ export class PolicyEngineService {
     this.policies.delete(policyId);
     this.clearPolicyCache(policyId);
 
-    logAuditEvent({
+    this.recordSecurityAudit({
+      eventType: 'POLICY_DELETE',
       action: 'policy_delete',
       resource: `policy/${policyId}`,
-      outcome: 'success',
-      details: { policyName: policy.name },
+      outcome: 'SUCCESS',
+      description: `Policy ${policy.name} deleted from policy-engine`,
       severity: 'high',
+      metadata: { policyId, policyName: policy.name },
     });
   }
 
@@ -328,16 +346,19 @@ export class PolicyEngineService {
             evaluatedAt: new Date(),
           };
 
-          logAuditEvent({
+          this.recordSecurityAudit({
+            eventType: 'POLICY_EVALUATION',
             action: 'policy_evaluation_emergency',
             resource: validatedRequest.resource,
-            outcome: 'success',
-            details: {
-              action: validatedRequest.action,
-              userId: validatedRequest.subject.userId,
-              decision: 'allow',
-            },
+            outcome: 'SUCCESS',
+            description: 'Emergency mode override bypassed normal policy evaluation',
             severity: 'critical',
+            userId: validatedRequest.subject.userId,
+            metadata: {
+              action: validatedRequest.action,
+              decision: 'allow',
+              emergencyMode: true,
+            },
           });
 
           return emergencyResult;
@@ -436,18 +457,25 @@ export class PolicyEngineService {
       this.evaluationMetrics.decisionsLast24h[overallDecision]++;
       this.evaluationMetrics.totalEvaluationTime += evaluationTime;
 
-      logAuditEvent({
+      this.recordSecurityAudit({
+        eventType: 'POLICY_EVALUATION',
         action: 'policy_evaluation',
         resource: validatedRequest.resource,
-        outcome: 'success',
-        details: {
+        outcome: overallDecision === 'allow' ? 'SUCCESS' : 'BLOCKED',
+        description: `Policy evaluation completed with ${overallDecision} decision`,
+        severity:
+          overallDecision === 'deny'
+            ? 'high'
+            : overallDecision === 'approval_required'
+              ? 'medium'
+              : 'low',
+        userId: validatedRequest.subject.userId,
+        metadata: {
           action: validatedRequest.action,
-          userId: validatedRequest.subject.userId,
           decision: overallDecision,
           policiesEvaluated: applicablePolicies.length,
           evaluationTimeMs: evaluationTime,
         },
-        severity: overallDecision === 'deny' ? 'high' : 'low',
       });
 
       return result;
@@ -455,17 +483,19 @@ export class PolicyEngineService {
       const evaluationTime = Date.now() - startTime;
       this.evaluationMetrics.totalEvaluationTime += evaluationTime;
 
-      logAuditEvent({
+      this.recordSecurityAudit({
+        eventType: 'POLICY_EVALUATION_ERROR',
         action: 'policy_evaluation',
         resource: validatedRequest.resource,
-        outcome: 'failure',
-        details: {
+        outcome: 'FAILURE',
+        description: 'Policy evaluation failed before a decision could be finalized',
+        severity: 'high',
+        userId: validatedRequest.subject.userId,
+        metadata: {
           action: validatedRequest.action,
-          userId: validatedRequest.subject.userId,
           error: error instanceof Error ? error.message : String(error),
           evaluationTimeMs: evaluationTime,
         },
-        severity: 'high',
       });
 
       throw new InternalServerError('Policy evaluation failed', {
@@ -531,6 +561,20 @@ export class PolicyEngineService {
       averageEvaluationTimeMs: averageEvaluationTime,
       cacheHitRate,
     };
+  }
+
+  /**
+   * Retrieve immutable audit trail entries recorded by the policy engine.
+   */
+  getSecurityAuditTrail(criteria: AuditQueryCriteria = {}): AuditChainEntry[] {
+    return this.securityAuditLogger.queryEntries(criteria);
+  }
+
+  /**
+   * Verify the immutable policy-engine audit trail hash chain.
+   */
+  verifySecurityAuditTrail(): AuditIntegrityReport {
+    return this.securityAuditLogger.getIntegrityReport();
   }
 
   // Private helper methods
@@ -775,19 +819,75 @@ export class PolicyEngineService {
       this.violations.set(violation.id, violation);
       this.evaluationMetrics.violationsLast24h++;
 
-      logAuditEvent({
+      this.recordSecurityAudit({
+        eventType: 'POLICY_VIOLATION',
         action: 'policy_violation',
         resource: request.resource,
-        outcome: 'success',
-        details: {
+        outcome: 'BLOCKED',
+        description: `Policy violation recorded for ${request.action}`,
+        severity: 'high',
+        userId: request.subject.userId,
+        metadata: {
           violationId: violation.id,
           policyId: match.policyId,
           policyName: match.policyName,
           severity: match.priority,
-          userId: request.subject.userId,
+          action: request.action,
         },
-        severity: 'high',
       });
+    }
+  }
+
+  private recordSecurityAudit(event: {
+    eventType: string;
+    action: string;
+    resource: string;
+    outcome: AuditEvent['outcome'];
+    description: string;
+    metadata?: Record<string, unknown>;
+    severity?: 'low' | 'medium' | 'high' | 'critical';
+    userId?: string;
+  }): void {
+    if (!this.config.auditEnabled) {
+      return;
+    }
+
+    this.securityAuditLogger.logEvent({
+      eventType: event.eventType,
+      service: this.serviceIdentity,
+      outcome: event.outcome,
+      description: event.description,
+      metadata: {
+        action: event.action,
+        resource: event.resource,
+        ...event.metadata,
+      },
+    });
+
+    logAuditEvent({
+      action: event.action,
+      resource: event.resource,
+      userId: event.userId,
+      outcome: this.toCoreAuditOutcome(event.outcome),
+      details: {
+        eventType: event.eventType,
+        description: event.description,
+        ...event.metadata,
+      },
+      severity: event.severity,
+    });
+  }
+
+  private toCoreAuditOutcome(outcome: AuditEvent['outcome']): 'success' | 'failure' | 'partial' {
+    switch (outcome) {
+      case 'SUCCESS':
+        return 'success';
+      case 'FAILURE':
+        return 'failure';
+      case 'BLOCKED':
+        return 'partial';
+      default:
+        return 'partial';
     }
   }
 }

--- a/services/policy-engine/tsconfig.json
+++ b/services/policy-engine/tsconfig.json
@@ -7,5 +7,9 @@
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts"],
-  "references": [{ "path": "../../packages/core" }, { "path": "../../packages/schemas" }]
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/security-core" },
+    { "path": "../../packages/schemas" }
+  ]
 }


### PR DESCRIPTION
## Summary
- extend @neurologix/security-core with queryable audit chain entries, integrity reports, and evidence checkpoints
- record immutable audit events in @neurologix/policy-engine for privileged mutations, evaluations, emergency overrides, and violations
- refresh workspace dependency wiring and add focused validation coverage for the new audit trail APIs

## In Scope
- packages/security-core
- services/policy-engine
- workspace lockfile / dependency wiring
- planning artifacts for Issue #35 selection, build evidence, and validator handoff

## Out of Scope
- fleet-wide mTLS rollout
- secrets scanning pipeline changes
- .github/ workflow/model edits
- Phase 8/9 delivery work

## Validation
- 
pm exec --workspace @neurologix/security-core -- vitest run --config vitest.config.ts
- 
pm --workspace @neurologix/security-core run build
- 
pm --workspace @neurologix/policy-engine test
- 
pm --workspace @neurologix/policy-engine run build
- 
pm run lint
- 
pm test
- 
pm run build

## Risks
- additional Issue #35 slices will still be required to roll immutable auditing out across more services
- workspace interoperability depends on the new ESM-compatible security-core build output remaining stable

## Rollback
- revert commit 3927006 to remove the bounded Issue #35 slice