### PR TITLE
feat(schemas): implement canonical API response/error schemas (Issue #81)

### DIFF
--- a/packages/schemas/src/api/index.test.ts
+++ b/packages/schemas/src/api/index.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import {
+  API_ERROR_CODE,
+  SERVICE_HEALTH_STATUS,
+  ApiErrorCodeSchema,
+  ApiErrorSchema,
+  ApiResponseMetaSchema,
+  ApiSuccessResponseSchema,
+  ApiErrorResponseSchema,
+  ApiResponseSchema,
+  PaginationMetaSchema,
+  PaginatedResponseSchema,
+  ServiceHealthSchema,
+  HealthCheckResponseSchema,
+} from './index.js';
+
+describe('API_ERROR_CODE', () => {
+  it('defines canonical error constants', () => {
+    expect(API_ERROR_CODE.BAD_REQUEST).toBe('BAD_REQUEST');
+    expect(API_ERROR_CODE.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
+    expect(API_ERROR_CODE.NOT_FOUND).toBe('NOT_FOUND');
+    expect(API_ERROR_CODE.INTERNAL_ERROR).toBe('INTERNAL_ERROR');
+  });
+});
+
+describe('ApiErrorCodeSchema', () => {
+  it('accepts known error codes', () => {
+    expect(ApiErrorCodeSchema.parse('BAD_REQUEST')).toBe('BAD_REQUEST');
+    expect(ApiErrorCodeSchema.parse('CONFLICT')).toBe('CONFLICT');
+  });
+
+  it('rejects unknown error codes', () => {
+    expect(() => ApiErrorCodeSchema.parse('SOMETHING_ELSE')).toThrow();
+  });
+});
+
+describe('ApiErrorSchema', () => {
+  it('parses minimal error payload and applies defaults', () => {
+    const parsed = ApiErrorSchema.parse({
+      code: API_ERROR_CODE.VALIDATION_ERROR,
+      message: 'Invalid request body',
+    });
+
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(parsed.retryable).toBe(false);
+  });
+
+  it('parses field-level errors', () => {
+    const parsed = ApiErrorSchema.parse({
+      code: API_ERROR_CODE.VALIDATION_ERROR,
+      message: 'Validation failed',
+      fieldErrors: [{ field: 'siteId', message: 'siteId is required' }],
+    });
+
+    expect(parsed.fieldErrors).toHaveLength(1);
+    expect(parsed.fieldErrors?.[0]?.field).toBe('siteId');
+  });
+});
+
+describe('ApiResponseMetaSchema', () => {
+  it('parses valid metadata', () => {
+    const parsed = ApiResponseMetaSchema.parse({
+      requestId: 'req-123',
+      timestamp: new Date().toISOString(),
+      traceId: 'trace-abc',
+    });
+
+    expect(parsed.requestId).toBe('req-123');
+    expect(parsed.traceId).toBe('trace-abc');
+  });
+
+  it('rejects invalid timestamp', () => {
+    expect(() =>
+      ApiResponseMetaSchema.parse({
+        requestId: 'req-123',
+        timestamp: 'not-a-date',
+      })
+    ).toThrow();
+  });
+});
+
+describe('ApiResponseSchema', () => {
+  const meta = {
+    requestId: 'req-123',
+    timestamp: new Date().toISOString(),
+  };
+
+  it('accepts success envelope', () => {
+    const success = ApiSuccessResponseSchema.parse({
+      success: true,
+      data: { id: 'site-1', name: 'Site Alpha' },
+      meta,
+    });
+
+    expect(success.success).toBe(true);
+    expect((success.data as { id: string }).id).toBe('site-1');
+  });
+
+  it('accepts error envelope', () => {
+    const error = ApiErrorResponseSchema.parse({
+      success: false,
+      error: {
+        code: API_ERROR_CODE.NOT_FOUND,
+        message: 'Site not found',
+      },
+      meta,
+    });
+
+    expect(error.success).toBe(false);
+    expect(error.error.code).toBe('NOT_FOUND');
+  });
+
+  it('discriminates by success field', () => {
+    const parsedSuccess = ApiResponseSchema.parse({ success: true, data: { ok: true }, meta });
+    const parsedError = ApiResponseSchema.parse({
+      success: false,
+      error: { code: API_ERROR_CODE.INTERNAL_ERROR, message: 'Unexpected error' },
+      meta,
+    });
+
+    expect(parsedSuccess.success).toBe(true);
+    expect(parsedError.success).toBe(false);
+  });
+});
+
+describe('PaginatedResponseSchema', () => {
+  const meta = {
+    requestId: 'req-234',
+    timestamp: new Date().toISOString(),
+  };
+
+  it('parses valid pagination metadata', () => {
+    const parsed = PaginationMetaSchema.parse({
+      page: 2,
+      pageSize: 25,
+      totalItems: 100,
+      totalPages: 4,
+      hasNext: true,
+      hasPrevious: true,
+    });
+
+    expect(parsed.page).toBe(2);
+    expect(parsed.totalPages).toBe(4);
+  });
+
+  it('rejects invalid page bounds', () => {
+    expect(() =>
+      PaginationMetaSchema.parse({
+        page: 0,
+        pageSize: 25,
+        totalItems: 10,
+        totalPages: 1,
+        hasNext: false,
+        hasPrevious: false,
+      })
+    ).toThrow();
+  });
+
+  it('parses paginated response envelope', () => {
+    const parsed = PaginatedResponseSchema.parse({
+      success: true,
+      data: [{ id: 'site-1' }, { id: 'site-2' }],
+      pagination: {
+        page: 1,
+        pageSize: 2,
+        totalItems: 2,
+        totalPages: 1,
+        hasNext: false,
+        hasPrevious: false,
+      },
+      meta,
+    });
+
+    expect(parsed.data).toHaveLength(2);
+    expect(parsed.pagination.totalItems).toBe(2);
+  });
+});
+
+describe('HealthCheckResponseSchema', () => {
+  it('defines health status constants', () => {
+    expect(SERVICE_HEALTH_STATUS.HEALTHY).toBe('healthy');
+    expect(SERVICE_HEALTH_STATUS.DEGRADED).toBe('degraded');
+    expect(SERVICE_HEALTH_STATUS.UNHEALTHY).toBe('unhealthy');
+  });
+
+  it('parses service health payload', () => {
+    const parsed = ServiceHealthSchema.parse({
+      service: 'recipe-executor',
+      status: 'healthy',
+      version: '1.0.0',
+      uptimeSeconds: 12345,
+      timestamp: new Date().toISOString(),
+      dependencies: [{ name: 'kafka', status: 'healthy', latencyMs: 12 }],
+    });
+
+    expect(parsed.service).toBe('recipe-executor');
+    expect(parsed.dependencies).toHaveLength(1);
+  });
+
+  it('parses health-check response envelope', () => {
+    const parsed = HealthCheckResponseSchema.parse({
+      success: true,
+      data: {
+        status: 'healthy',
+        services: [
+          {
+            service: 'mission-control',
+            status: 'healthy',
+            version: '1.0.0',
+            uptimeSeconds: 54321,
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      },
+      meta: {
+        requestId: 'req-health',
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.services[0]?.service).toBe('mission-control');
+  });
+});

--- a/packages/schemas/src/api/index.ts
+++ b/packages/schemas/src/api/index.ts
@@ -1,5 +1,176 @@
 /**
- * @fileoverview API schemas for REST and GraphQL endpoints
+ * @fileoverview Canonical API schemas for NeuroLogix service contracts
+ *
+ * Defines shared response envelopes, structured error payloads, pagination
+ * metadata, and health-check responses used across REST/SSE surfaces.
+ *
+ * Model ref: contracts/*.yaml (API request/response/error schema families)
  */
 
-// Placeholder - will be implemented in Phase 2
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API Error Codes
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const API_ERROR_CODE = {
+	BAD_REQUEST: 'BAD_REQUEST',
+	VALIDATION_ERROR: 'VALIDATION_ERROR',
+	UNAUTHORIZED: 'UNAUTHORIZED',
+	FORBIDDEN: 'FORBIDDEN',
+	NOT_FOUND: 'NOT_FOUND',
+	CONFLICT: 'CONFLICT',
+	RATE_LIMITED: 'RATE_LIMITED',
+	TIMEOUT: 'TIMEOUT',
+	SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+	INTERNAL_ERROR: 'INTERNAL_ERROR',
+} as const;
+
+export type ApiErrorCode = (typeof API_ERROR_CODE)[keyof typeof API_ERROR_CODE];
+export const ApiErrorCodeSchema = z.enum([
+	'BAD_REQUEST',
+	'VALIDATION_ERROR',
+	'UNAUTHORIZED',
+	'FORBIDDEN',
+	'NOT_FOUND',
+	'CONFLICT',
+	'RATE_LIMITED',
+	'TIMEOUT',
+	'SERVICE_UNAVAILABLE',
+	'INTERNAL_ERROR',
+]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error Details
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ApiFieldErrorSchema = z.object({
+	field: z.string().min(1),
+	message: z.string().min(1),
+	code: z.string().optional(),
+});
+
+export type ApiFieldError = z.infer<typeof ApiFieldErrorSchema>;
+
+export const ApiErrorSchema = z.object({
+	code: ApiErrorCodeSchema,
+	message: z.string().min(1),
+	details: z.record(z.unknown()).optional(),
+	fieldErrors: z.array(ApiFieldErrorSchema).optional(),
+	retryable: z.boolean().default(false),
+});
+
+export type ApiError = z.infer<typeof ApiErrorSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response Metadata
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ApiResponseMetaSchema = z.object({
+	requestId: z.string().min(1),
+	timestamp: z.string().datetime(),
+	traceId: z.string().optional(),
+	siteId: z.string().optional(),
+	version: z.string().optional(),
+});
+
+export type ApiResponseMeta = z.infer<typeof ApiResponseMetaSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response Envelopes
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ApiSuccessResponseSchema = z.object({
+	success: z.literal(true),
+	data: z.unknown(),
+	meta: ApiResponseMetaSchema,
+});
+
+export type ApiSuccessResponse<T = unknown> = Omit<z.infer<typeof ApiSuccessResponseSchema>, 'data'> & {
+	data: T;
+};
+
+export const ApiErrorResponseSchema = z.object({
+	success: z.literal(false),
+	error: ApiErrorSchema,
+	meta: ApiResponseMetaSchema,
+});
+
+export type ApiErrorResponse = z.infer<typeof ApiErrorResponseSchema>;
+
+export const ApiResponseSchema = z.discriminatedUnion('success', [
+	ApiSuccessResponseSchema,
+	ApiErrorResponseSchema,
+]);
+
+export type ApiResponse<T = unknown> = ApiSuccessResponse<T> | ApiErrorResponse;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pagination
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const PaginationMetaSchema = z.object({
+	page: z.number().int().min(1),
+	pageSize: z.number().int().min(1).max(1000),
+	totalItems: z.number().int().min(0),
+	totalPages: z.number().int().min(0),
+	hasNext: z.boolean(),
+	hasPrevious: z.boolean(),
+});
+
+export type PaginationMeta = z.infer<typeof PaginationMetaSchema>;
+
+export const PaginatedResponseSchema = z.object({
+	success: z.literal(true),
+	data: z.array(z.unknown()),
+	pagination: PaginationMetaSchema,
+	meta: ApiResponseMetaSchema,
+});
+
+export type PaginatedResponse<T = unknown> = Omit<z.infer<typeof PaginatedResponseSchema>, 'data'> & {
+	data: T[];
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Health
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const SERVICE_HEALTH_STATUS = {
+	HEALTHY: 'healthy',
+	DEGRADED: 'degraded',
+	UNHEALTHY: 'unhealthy',
+} as const;
+
+export type ServiceHealthStatus = (typeof SERVICE_HEALTH_STATUS)[keyof typeof SERVICE_HEALTH_STATUS];
+export const ServiceHealthStatusSchema = z.enum(['healthy', 'degraded', 'unhealthy']);
+
+export const ServiceDependencySchema = z.object({
+	name: z.string().min(1),
+	status: ServiceHealthStatusSchema,
+	latencyMs: z.number().min(0).optional(),
+	message: z.string().optional(),
+});
+
+export type ServiceDependency = z.infer<typeof ServiceDependencySchema>;
+
+export const ServiceHealthSchema = z.object({
+	service: z.string().min(1),
+	status: ServiceHealthStatusSchema,
+	version: z.string().min(1),
+	uptimeSeconds: z.number().min(0),
+	timestamp: z.string().datetime(),
+	dependencies: z.array(ServiceDependencySchema).default([]),
+});
+
+export type ServiceHealth = z.infer<typeof ServiceHealthSchema>;
+
+export const HealthCheckResponseSchema = z.object({
+	success: z.literal(true),
+	data: z.object({
+		status: ServiceHealthStatusSchema,
+		services: z.array(ServiceHealthSchema),
+	}),
+	meta: ApiResponseMetaSchema,
+});
+
+export type HealthCheckResponse = z.infer<typeof HealthCheckResponseSchema>;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -16,4 +16,4 @@ export * from './intents/index.js';
 export * from './recipes/index.js';
 export * from './assets/index.js';
 export * from './audit/index.js';
-// export * from './api/index.js';
+export * from './api/index.js';


### PR DESCRIPTION
## Summary
Implements the remaining packages/schemas/src/api/index.ts placeholder with canonical API contracts for shared response envelopes and health payloads.

Closes #81

## What changed
- Added canonical API error vocabulary via API_ERROR_CODE
- Added ApiErrorSchema with structured details and field-level validation errors
- Added envelope schemas:
  - ApiSuccessResponseSchema
  - ApiErrorResponseSchema
  - ApiResponseSchema (discriminated union)
- Added pagination contracts:
  - PaginationMetaSchema
  - PaginatedResponseSchema
- Added health contracts:
  - ServiceHealthStatusSchema
  - ServiceDependencySchema
  - ServiceHealthSchema
  - HealthCheckResponseSchema
- Enabled xport * from './api/index.js'; in schemas barrel (packages/schemas/src/index.ts)
- Added packages/schemas/src/api/index.test.ts with 16 tests

## Validation
- 
px vitest run packages/schemas/src/api → **16/16 passing**
- 
px tsc --noEmit -p packages/schemas/tsconfig.json → **pass**
- 
px eslint packages/schemas/src/api/index.ts packages/schemas/src/api/index.test.ts packages/schemas/src/index.ts → **pass**

## Notes
- Scope is intentionally generic and transport-agnostic (no endpoint-specific payload schemas).
- Existing packages/core API types can be migrated to these canonical schemas in a follow-up de-duplication issue.