### PR TITLE
chore(schemas): remove stale placeholder header from assets module (Issue #85)

### DIFF
--- a/packages/schemas/src/assets/index.ts
+++ b/packages/schemas/src/assets/index.ts
@@ -1,9 +1,4 @@
 /**
- * @fileoverview Asset schemas for industrial equipment
- */
-
-// Placeholder - will be implemented in Phase 2
-/**
  * @fileoverview Canonical asset schemas for NeuroLogix ICS industrial equipment
  *
  * Assets are the physical and logical equipment entities (PLCs, conveyors, cameras,


### PR DESCRIPTION
## Summary
Removes stale placeholder comment/header text from packages/schemas/src/assets/index.ts.

Closes #85

## Why
The canonical asset schemas are fully implemented, but the file still contained legacy placeholder text that implied the module was incomplete.

## Scope
- Comment/header cleanup only
- No schema logic changes

## Validation
- 
px eslint packages/schemas/src/assets/index.ts ✅
- 
px tsc --noEmit -p packages/schemas/tsconfig.json ✅
