### PR TITLE
chore(agent-handoff): restore dispatch-code-chat helper script

### DIFF
--- a/.utils/dispatch-code-chat.ps1
+++ b/.utils/dispatch-code-chat.ps1
@@ -1,0 +1,133 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('ask')]
+    [string]$Mode,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$TargetAgent,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PromptFile,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$AddFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepositoryRoot {
+    try {
+        $repositoryRoot = (& git rev-parse --show-toplevel 2>$null).Trim()
+        if ([string]::IsNullOrWhiteSpace($repositoryRoot)) {
+            throw 'git did not return a repository root path.'
+        }
+
+        return $repositoryRoot
+    }
+    catch {
+        throw 'Unable to resolve repository root. Run this command from inside the NeuroLogix repository.'
+    }
+}
+
+function Resolve-ExistingFilePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryRoot
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "Parameter -$ParameterName cannot be empty."
+    }
+
+    $resolvedCandidate = if ([System.IO.Path]::IsPathRooted($Path)) {
+        $Path
+    }
+    else {
+        Join-Path -Path $RepositoryRoot -ChildPath $Path
+    }
+
+    if (-not (Test-Path -LiteralPath $resolvedCandidate -PathType Leaf)) {
+        throw "File provided to -$ParameterName was not found: '$Path' (resolved: '$resolvedCandidate')."
+    }
+
+    return (Resolve-Path -LiteralPath $resolvedCandidate).Path
+}
+
+function Resolve-CodeCliPath {
+    $codeCommand = Get-Command -Name 'code.cmd' -ErrorAction SilentlyContinue
+    if ($null -ne $codeCommand) {
+        return $codeCommand.Source
+    }
+
+    $codeCommand = Get-Command -Name 'code' -ErrorAction SilentlyContinue
+    if ($null -ne $codeCommand) {
+        return $codeCommand.Source
+    }
+
+    $fallbackPath = Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Programs\Microsoft VS Code\bin\code.cmd'
+    if (Test-Path -LiteralPath $fallbackPath -PathType Leaf) {
+        return $fallbackPath
+    }
+
+    throw 'Unable to locate the VS Code CLI (`code` or `code.cmd`). Install it from VS Code and ensure it is on PATH.'
+}
+
+try {
+    $repositoryRoot = Resolve-RepositoryRoot
+    $resolvedPromptFile = Resolve-ExistingFilePath -Path $PromptFile -ParameterName 'PromptFile' -RepositoryRoot $repositoryRoot
+
+    $addFileEntries = @(
+        $AddFile -split ',' |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+
+    if ($addFileEntries.Count -eq 0) {
+        throw 'Parameter -AddFile did not contain any file paths. Provide one or more comma-separated paths.'
+    }
+
+    $resolvedAddFiles = @()
+    foreach ($entry in $addFileEntries) {
+        $resolvedAddFiles += Resolve-ExistingFilePath -Path $entry -ParameterName 'AddFile' -RepositoryRoot $repositoryRoot
+    }
+
+    $promptContent = Get-Content -LiteralPath $resolvedPromptFile -Raw
+    if ([string]::IsNullOrWhiteSpace($promptContent)) {
+        throw "Prompt file '$PromptFile' is empty."
+    }
+
+    $codeCliPath = Resolve-CodeCliPath
+
+    $arguments = @('chat', '-m', $TargetAgent)
+    foreach ($filePath in $resolvedAddFiles) {
+        $arguments += @('--add-file', $filePath)
+    }
+
+    $arguments += $promptContent
+
+    Write-Host "Dispatching mode '$Mode' to agent '$TargetAgent'..."
+    & $codeCliPath @arguments
+
+    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    if ($exitCode -ne 0) {
+        throw "VS Code chat dispatch failed with exit code $exitCode."
+    }
+
+    Write-Host 'Dispatch completed successfully.'
+    exit 0
+}
+catch {
+    Write-Error $_.Exception.Message
+    exit 1
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,28 @@ security: implement rate limiting
    - Ensure CI/CD passes
    - Delete feature branch after merge
 
+### Agent Handoff Dispatch
+
+Use the repository helper script to dispatch planner/builder/validator handoffs
+from repo root:
+
+```powershell
+.\.utils\dispatch-code-chat.ps1 -Mode ask -TargetAgent "validator-merger" -PromptFile "planning/handoff-to-validator-issue-87.md" -AddFile "README.md,CONTRIBUTING.md"
+```
+
+Parameters:
+
+- `-Mode`: Dispatch mode (`ask`)
+- `-TargetAgent`: Copilot chat agent/model name
+- `-PromptFile`: Path to markdown/text prompt file consumed as chat prompt
+- `-AddFile`: Comma-separated list of context files added to the chat request
+
+Failure behavior:
+
+- Missing prompt/context files return non-zero exit status
+- Missing required parameters return non-zero exit status
+- VS Code CLI dispatch failures return non-zero exit status with actionable errors
+
 ## Code Review Guidelines
 
 ### What to Look For

--- a/planning/issue-selection-issue-89.md
+++ b/planning/issue-selection-issue-89.md
@@ -1,0 +1,32 @@
+# Issue Selection Record — Issue #89
+
+Date: 2026-03-10
+Agent Mode: `auto-agent`
+Repository: `Coding-Krakken/NeuroLogix`
+
+## Candidate Scan
+
+Open issues snapshot (`gh issue list --state open --limit 30`):
+- `#89` chore(agent-handoff): restore dispatch-code-chat helper script
+
+## Selection Decision
+
+Selected issue: **#89**
+
+Rationale:
+1. It is the only open issue and therefore highest-priority actionable backlog item.
+2. It blocks deterministic planner/builder/validator handoff automation.
+3. Scope is bounded and directly verifiable with command-level tests.
+
+## Planned Bounded Slice
+
+In scope:
+- Add `.utils/dispatch-code-chat.ps1` with `-Mode`, `-TargetAgent`, `-PromptFile`, and `-AddFile` support.
+- Implement deterministic path resolution and explicit failures for missing files.
+- Add developer-facing usage documentation with a validated command example.
+- Capture validation evidence in planning artifacts.
+
+Out of scope:
+- Reworking the orchestration framework.
+- Recreating missing historical `.github/templates/*` files referenced by older handoff docs.
+- Updating all legacy planning files in this issue.

--- a/planning/validation-evidence-issue-89.md
+++ b/planning/validation-evidence-issue-89.md
@@ -1,0 +1,58 @@
+# Validation Evidence — Issue #89
+
+Date: 2026-03-10
+Work Item: `#89`
+Branch: `main` (local bounded implementation)
+
+## Changed Files
+
+- `.utils/dispatch-code-chat.ps1`
+- `CONTRIBUTING.md`
+- `planning/issue-selection-issue-89.md`
+
+## Commands and Outcomes
+
+1. Success-path dispatch validation:
+
+```powershell
+.\.utils\dispatch-code-chat.ps1 -Mode ask -TargetAgent "validator-merger" -PromptFile "planning/handoff-to-validator-issue-87.md" -AddFile "README.md,CONTRIBUTING.md"
+```
+
+- Result: PASS
+- Output included: `Dispatch completed successfully.`
+- Exit code: `0`
+
+2. Missing prompt file validation:
+
+```powershell
+.\.utils\dispatch-code-chat.ps1 -Mode ask -TargetAgent "validator-merger" -PromptFile "planning/does-not-exist.md" -AddFile "README.md"
+```
+
+- Result: PASS (expected failure mode)
+- Output included: `File provided to -PromptFile was not found...`
+- Exit code: `1`
+
+3. Missing add-file validation:
+
+```powershell
+.\.utils\dispatch-code-chat.ps1 -Mode ask -TargetAgent "validator-merger" -PromptFile "planning/handoff-to-validator-issue-87.md" -AddFile "does-not-exist.md"
+```
+
+- Result: PASS (expected failure mode)
+- Output included: `File provided to -AddFile was not found...`
+- Exit code: `1`
+
+## Acceptance Criteria Mapping
+
+1. Script exists at `.utils/dispatch-code-chat.ps1` and runs from repo root.
+   - PASS: script added and success-path command executed from repo root.
+2. Existing handoff commands execute without "script not found" errors.
+   - PASS: dispatch helper is now present and executable; command execution reaches validation/dispatch logic.
+3. Failure modes return actionable messages and non-zero exit status.
+   - PASS: missing prompt and missing add-file both emit explicit errors and exit code `1`.
+4. Documentation includes at least one validated command example.
+   - PASS: `CONTRIBUTING.md` includes usage example and parameter details.
+
+## Notes
+
+- Additional repo drift discovered: historical handoff commands reference `.github/templates/*`, which are currently absent in this repository. This issue intentionally remains bounded to restoring the dispatch helper script and usage docs.


### PR DESCRIPTION
## Summary

Restores the .utils/dispatch-code-chat.ps1 PowerShell helper script that agent handoff workflows depend on.

## Problem

The autonomous handoff workflow references \.utils/dispatch-code-chat.ps1\, but the script did not exist in the repository. This blocked deterministic planner/builder/validator dispatch from local PowerShell sessions and caused all handoff commands to fail with 'script not found'.

## Changes

- **Added** \.utils/dispatch-code-chat.ps1\ — 133-line idiomatic PowerShell implementing:
  - \-Mode\ (required, validates to \sk\)
  - \-TargetAgent\ (required)
  - \-PromptFile\ (required, validated to exist)
  - \-AddFile\ (required, comma-separated, each validated to exist)
  - Deterministic repo-root resolution via \git rev-parse --show-toplevel\
  - VS Code CLI path resolution (PATH then known fallback)
  - Explicit error messages and exit code 1 on all failure paths
- **Updated** \CONTRIBUTING.md\ — Added §\u202fAgent Handoff Dispatch documenting parameters and a validated command example
- **Added** \planning/issue-selection-issue-89.md\ — Issue selection record
- **Added** \planning/validation-evidence-issue-89.md\ — Full test evidence for all acceptance criteria

## Validation

All acceptance criteria verified:

| Criteria | Result |
|---|---|
| Script exists and runs from repo root | ✅ PASS |
| Existing handoff commands execute without 'script not found' errors | ✅ PASS |
| Missing prompt file → actionable error + exit 1 | ✅ PASS |
| Missing add-file → actionable error + exit 1 | ✅ PASS |
| Documentation includes validated command example | ✅ PASS |

## Notes

Historical handoff files reference \.github/templates/*\ files that are absent in the repo. This drift is observed but intentionally out-of-scope for this bounded issue.

Closes #89