### PR TITLE
test(schemas): improve broker schema coverage to 100% (#94)

### DIFF
--- a/packages/schemas/src/broker/index.test.ts
+++ b/packages/schemas/src/broker/index.test.ts
@@ -7,6 +7,29 @@ import {
   evaluateTopicContractCompatibility,
 } from '@/broker/index';
 
+// ─── Shared test fixtures ──────────────────────────────────────────────────
+
+const kafkaContract = (overrides: object = {}): object => ({
+  backend: 'kafka-redpanda',
+  topic: 'nlx.telemetry.asset.v1',
+  version: { major: 1, minor: 0, patch: 0 },
+  payloadSchemaId: 'telemetry.asset.v1',
+  compatibility: 'backward',
+  partitions: 6,
+  retentionHours: 168,
+  ...overrides,
+});
+
+const sparkplugContract = (overrides: object = {}): object => ({
+  backend: 'mqtt-sparkplug',
+  topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+  version: { major: 1, minor: 0, patch: 0 },
+  payloadSchemaId: 'sparkplug.telemetry.v1',
+  compatibility: 'backward',
+  qos: 'at-least-once',
+  ...overrides,
+});
+
 describe('Broker Topic Governance', () => {
   describe('BrokerTopicContractSchema', () => {
     it('validates Sparkplug contract topics', () => {
@@ -49,6 +72,17 @@ describe('Broker Topic Governance', () => {
       expect(result.success).toBe(true);
     });
 
+    it('validates service principal ACL for MQTT Sparkplug topics with valid spBv1.0/ pattern', () => {
+      const result = BrokerAclRuleSchema.safeParse({
+        principal: 'svc.digital-twin',
+        backend: 'mqtt-sparkplug',
+        operation: 'subscribe',
+        topicPattern: 'spBv1.0/line-a/DDATA/#',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
     it('rejects ACL rules that use non-service principals', () => {
       const result = BrokerAclRuleSchema.safeParse({
         principal: 'user.alice',
@@ -70,55 +104,40 @@ describe('Broker Topic Governance', () => {
 
       expect(result.success).toBe(false);
     });
+
+    it('rejects Kafka ACL patterns that do not start with nlx.', () => {
+      const result = BrokerAclRuleSchema.safeParse({
+        principal: 'svc.digital-twin',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topicPattern: 'spBv1.0/line-a/DDATA/#',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toContain('must start with nlx.');
+      }
+    });
   });
 
   describe('Contract compatibility', () => {
     it('passes for a compatible minor version update', () => {
-      const previous = BrokerTopicContractSchema.parse({
-        backend: 'kafka-redpanda',
-        topic: 'nlx.telemetry.asset.v1',
-        version: { major: 1, minor: 0, patch: 0 },
-        payloadSchemaId: 'telemetry.asset.v1',
-        compatibility: 'full',
-        partitions: 6,
-        retentionHours: 168,
-      });
-
-      const next = BrokerTopicContractSchema.parse({
-        backend: 'kafka-redpanda',
-        topic: 'nlx.telemetry.asset.v1',
-        version: { major: 1, minor: 1, patch: 0 },
-        payloadSchemaId: 'telemetry.asset.v1',
-        compatibility: 'full',
-        partitions: 6,
-        retentionHours: 168,
-      });
+      const previous = BrokerTopicContractSchema.parse(kafkaContract({ compatibility: 'full' }));
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 1, patch: 0 }, compatibility: 'full' }),
+      );
 
       expect(evaluateTopicContractCompatibility(previous, next)).toEqual({ compatible: true });
       expect(() => assertTopicContractCompatible(previous, next)).not.toThrow();
     });
 
     it('fails when payload schema changes without major version bump', () => {
-      const previous = BrokerTopicContractSchema.parse({
-        backend: 'kafka-redpanda',
-        topic: 'nlx.telemetry.asset.v1',
-        version: { major: 1, minor: 2, patch: 0 },
-        payloadSchemaId: 'telemetry.asset.v1',
-        compatibility: 'backward',
-        partitions: 6,
-        retentionHours: 168,
-      });
-
-      const next = BrokerTopicContractSchema.parse({
-        backend: 'kafka-redpanda',
-        topic: 'nlx.telemetry.asset.v1',
-        version: { major: 1, minor: 3, patch: 0 },
-        payloadSchemaId: 'telemetry.asset.v2',
-        compatibility: 'backward',
-        partitions: 6,
-        retentionHours: 168,
-      });
-
+      const previous = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 2, patch: 0 } }),
+      );
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 3, patch: 0 }, payloadSchemaId: 'telemetry.asset.v2' }),
+      );
       const result = evaluateTopicContractCompatibility(previous, next);
       expect(result.compatible).toBe(false);
       expect(() => assertTopicContractCompatible(previous, next)).toThrow(
@@ -127,28 +146,113 @@ describe('Broker Topic Governance', () => {
     });
 
     it('passes when breaking payload change increments major version', () => {
-      const previous = BrokerTopicContractSchema.parse({
-        backend: 'kafka-redpanda',
-        topic: 'nlx.telemetry.asset.v1',
-        version: { major: 1, minor: 5, patch: 0 },
-        payloadSchemaId: 'telemetry.asset.v1',
-        compatibility: 'backward',
-        partitions: 6,
-        retentionHours: 168,
-      });
-
-      const next = BrokerTopicContractSchema.parse({
-        backend: 'kafka-redpanda',
-        topic: 'nlx.telemetry.asset.v1',
-        version: { major: 2, minor: 0, patch: 0 },
-        payloadSchemaId: 'telemetry.asset.v2',
-        compatibility: 'backward',
-        partitions: 6,
-        retentionHours: 168,
-      });
+      const previous = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 5, patch: 0 } }),
+      );
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 2, minor: 0, patch: 0 }, payloadSchemaId: 'telemetry.asset.v2' }),
+      );
 
       expect(evaluateTopicContractCompatibility(previous, next)).toEqual({ compatible: true });
       expect(() => assertTopicContractCompatible(previous, next)).not.toThrow();
+    });
+
+    it('fails when backend changes between contracts', () => {
+      const previous = BrokerTopicContractSchema.parse(kafkaContract());
+      const next = BrokerTopicContractSchema.parse(sparkplugContract());
+
+      const result = evaluateTopicContractCompatibility(previous, next);
+      expect(result.compatible).toBe(false);
+      if (!result.compatible) {
+        expect(result.reason).toContain('Backend changed');
+      }
+      expect(() => assertTopicContractCompatible(previous, next)).toThrow('Backend changed');
+    });
+
+    it('fails when topic name changes between contracts', () => {
+      const previous = BrokerTopicContractSchema.parse(kafkaContract());
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ topic: 'nlx.intents.commands.v1' }),
+      );
+
+      const result = evaluateTopicContractCompatibility(previous, next);
+      expect(result.compatible).toBe(false);
+      if (!result.compatible) {
+        expect(result.reason).toContain('Topic name changed');
+      }
+      expect(() => assertTopicContractCompatible(previous, next)).toThrow('Topic name changed');
+    });
+
+    it('fails when contract version regresses (minor version)', () => {
+      const previous = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 5, patch: 0 } }),
+      );
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 4, patch: 0 } }),
+      );
+
+      const result = evaluateTopicContractCompatibility(previous, next);
+      expect(result.compatible).toBe(false);
+      if (!result.compatible) {
+        expect(result.reason).toContain('version regressed');
+      }
+      expect(() => assertTopicContractCompatible(previous, next)).toThrow('version regressed');
+    });
+
+    it('fails when patch version regresses (compareVersion patch-level path)', () => {
+      const previous = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 0, patch: 5 } }),
+      );
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 0, patch: 3 } }),
+      );
+
+      const result = evaluateTopicContractCompatibility(previous, next);
+      expect(result.compatible).toBe(false);
+      if (!result.compatible) {
+        expect(result.reason).toContain('version regressed');
+      }
+      expect(() => assertTopicContractCompatible(previous, next)).toThrow('version regressed');
+    });
+
+    it('passes when only patch version increments', () => {
+      const previous = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 0, patch: 2 } }),
+      );
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 0, patch: 3 } }),
+      );
+
+      expect(evaluateTopicContractCompatibility(previous, next)).toEqual({ compatible: true });
+    });
+
+    it('fails when compatibility mode is downgraded from full to backward', () => {
+      const previous = BrokerTopicContractSchema.parse(
+        kafkaContract({ compatibility: 'full', version: { major: 1, minor: 1, patch: 0 } }),
+      );
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ compatibility: 'backward', version: { major: 1, minor: 2, patch: 0 } }),
+      );
+
+      const result = evaluateTopicContractCompatibility(previous, next);
+      expect(result.compatible).toBe(false);
+      if (!result.compatible) {
+        expect(result.reason).toContain('Compatibility mode cannot be downgraded');
+      }
+      expect(() => assertTopicContractCompatible(previous, next)).toThrow(
+        'Compatibility mode cannot be downgraded from full to backward.',
+      );
+    });
+
+    it('passes when compatibility mode stays the same (backward -> backward)', () => {
+      const previous = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 0, patch: 0 } }),
+      );
+      const next = BrokerTopicContractSchema.parse(
+        kafkaContract({ version: { major: 1, minor: 1, patch: 0 } }),
+      );
+
+      expect(evaluateTopicContractCompatibility(previous, next)).toEqual({ compatible: true });
     });
   });
 });


### PR DESCRIPTION
## Summary

Improves broker topic governance schema test coverage from 81.74% statements / 72.72% branches to **100% across all metrics**.

Closes #94

## Problem

`packages/schemas/src/broker/index.ts` had 5 untested code paths in `evaluateTopicContractCompatibility()` and `compareVersion()`, leaving branches for backend-changed, topic-name-changed, version regression (minor + patch), and compatibility-mode downgrade entirely uncovered.

## Changes

- **Shared fixture helpers** — `kafkaContract()` and `sparkplugContract()` factory functions eliminate repeated boilerplate and make intent explicit
- **MQTT Sparkplug ACL test** — covers `BrokerAclRuleSchema` validation for `mqtt-sparkplug` backend (lines 95–96)
- **Backend-changed guard** — contract incompatibility when `backend` differs (lines 107–111)
- **Topic-name-changed guard** — contract incompatibility when `topic` differs (lines 114–118)
- **Minor version regression** — `evaluateTopicContractCompatibility` rejects regressions (lines 121–125)
- **Patch version regression** — exercises `compareVersion` patch-level comparison (line 80, 128–133)
- **Patch-only increment** — passes as compatible
- **Compatibility mode downgrade** — `full → backward` is rejected (lines 139–143)
- **Compatibility mode stable** — `backward → backward` passes

## Validation

```
Tests  246 passed (246)

src/broker/index.ts  | 100% stmts | 100% branch | 100% funcs | 100% lines
```

All 10 test files, 246 tests passing. No regressions.

## Checklist

- [x] Tests added for all new code paths
- [x] 100% statement, branch, function, and line coverage on broker module
- [x] No lint errors
- [x] No type errors
- [x] Existing tests refactored to use shared fixtures (DRY improvement)
