### PR TITLE
docs: scaffold missing documentation directories declared in README (#96)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,24 @@
+# API Documentation
+
+## Purpose
+
+This directory contains NeuroLogix API reference documentation for service and
+application boundaries (REST, SSE, and contract-governed message surfaces).
+
+## Current Status
+
+Foundational scaffold. API contracts are currently authored first in:
+
+- `.github/.system-state/contracts/`
+- `packages/schemas/src/`
+
+## Near-Term Contents
+
+- Endpoint index by service (`services/*`)
+- Request/response/error schema references
+- SSE stream event contract notes for Mission Control
+
+## Related Architecture Evidence
+
+- [ADR-006: Schema Registry and Contracts](../architecture/ADR-006-schema-registry-contracts.md)
+- [Phase 1 Definition of Ready](../architecture/phase-1-definition-of-ready.md)

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,22 @@
+# Compliance Documentation
+
+## Purpose
+
+This directory contains compliance and security alignment documentation for
+NeuroLogix controls, policies, and evidence tracking.
+
+## Current Status
+
+Foundational scaffold. Security and compliance direction is currently anchored
+in architecture ADRs and repository governance docs.
+
+## Near-Term Contents
+
+- IEC 62443 control mapping
+- ISO 27001 / NIST CSF alignment matrix
+- Audit evidence and review cadence
+
+## Related Architecture Evidence
+
+- [ADR-003: Security-First Architecture](../architecture/ADR-003-security-first-architecture.md)
+- [README Security & Compliance section](../../README.md)

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,25 @@
+# Deployment Documentation
+
+## Purpose
+
+This directory contains deployment and release guidance for local development,
+staging, and production rollout flows.
+
+## Current Status
+
+Foundational scaffold. Current deployment references are split across:
+
+- `infrastructure/docker/`
+- repository root `README.md`
+- CI workflow definitions in `.github/workflows/`
+
+## Near-Term Contents
+
+- Environment topology and prerequisites
+- Build, image, and rollout sequence
+- Canary and rollback procedures
+
+## Related Architecture Evidence
+
+- [ADR-002: TypeScript and Build System](../architecture/ADR-002-typescript-build-system.md)
+- [Phase 0 Gap Report](../architecture/phase-0-gap-report.md)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,24 @@
+# Operations Runbooks
+
+## Purpose
+
+This directory contains operational runbooks for incident response, service
+recovery, and safe-mode procedures.
+
+## Current Status
+
+Foundational scaffold. Existing operational guidance also lives in:
+
+- `.developer/RUNBOOKS/`
+- planning validation and closure records under `planning/`
+
+## Near-Term Contents
+
+- Service incident triage playbooks
+- Rollback and safe-state activation steps
+- Validation checklist references for critical paths
+
+## Related Architecture Evidence
+
+- [ADR-004: Observability Strategy](../architecture/ADR-004-observability-strategy.md)
+- [Phase 0 Gap Report](../architecture/phase-0-gap-report.md)


### PR DESCRIPTION
## Summary
Adds missing documentation directory scaffolds declared in `README.md` so on-disk structure matches documented repository layout.

Closes #96

## Changes
- Added `docs/api/README.md`
- Added `docs/deployment/README.md`
- Added `docs/compliance/README.md`
- Added `docs/runbooks/README.md`

Each scaffold includes directory purpose, current status, and links to existing architecture evidence.

## Validation
- `npm run lint` (PASS; warnings-only baseline unchanged)
- Manual directory verification for `docs/api`, `docs/deployment`, `docs/compliance`, and `docs/runbooks`

## Risk / Rollback
- Low risk (documentation-only change)
- Rollback by reverting commit `b8642c5`
