### PR TITLE
feat(schemas): broker topic governance runtime enforcement (#103)

### DIFF
--- a/packages/schemas/src/broker/governance.test.ts
+++ b/packages/schemas/src/broker/governance.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+
+import { BROKER_TOPIC_CONTRACTS, BrokerTopicContractSchema } from './index';
+import {
+  assertTopicRegistryGuard,
+  isSafetyCriticalTopic,
+  type TopicValidationResult,
+  validateTopicAgainstContract,
+  validateTopicRegistrationAgainstContracts,
+  validateTopicRegistryGuard,
+} from './governance';
+import { SITE_TIER } from '../federation/index';
+
+describe('Broker Topic Governance Runtime Enforcement', () => {
+  const telemetryContract = BROKER_TOPIC_CONTRACTS.find(
+    (contract) => contract.topic === 'nlx.telemetry.asset.v1'
+  );
+
+  const apiContract = BROKER_TOPIC_CONTRACTS.find(
+    (contract) => contract.topic === 'nlx.api.federation.v1'
+  );
+
+  const sparkplugContract = BROKER_TOPIC_CONTRACTS.find(
+    (contract) => contract.topic === 'spBv1.0/line-a/DDATA/plc-01/conveyor-01'
+  );
+
+  it('loads canonical broker topic contracts for runtime governance', () => {
+    expect(BROKER_TOPIC_CONTRACTS.length).toBeGreaterThanOrEqual(5);
+    expect(telemetryContract).toBeDefined();
+    expect(apiContract).toBeDefined();
+    expect(sparkplugContract).toBeDefined();
+  });
+
+  it('validates a conformant registration against the canonical contract registry', () => {
+    const registration = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.telemetry.asset.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'telemetry.asset.v1',
+      compatibility: 'full',
+      partitions: 12,
+      retentionHours: 168,
+      deadLetterTopic: 'nlx.telemetry.asset.v1.dlq',
+    });
+
+    const result = validateTopicRegistrationAgainstContracts(registration);
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.contract?.topic).toEqual('nlx.telemetry.asset.v1');
+  });
+
+  it('detects topic name mismatches when registration topic is not in the registry', () => {
+    const registration = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.telemetry.unregistered.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'telemetry.asset.v1',
+      compatibility: 'backward',
+      partitions: 12,
+      retentionHours: 168,
+      deadLetterTopic: 'nlx.telemetry.unregistered.v1.dlq',
+    });
+
+    const result = validateTopicRegistrationAgainstContracts(registration);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]).toContain('No broker topic contract found');
+  });
+
+  it('detects backend mismatches when registration is validated against an incompatible contract', () => {
+    const kafkaRegistration = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.telemetry.asset.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'telemetry.asset.v1',
+      compatibility: 'full',
+      partitions: 12,
+      retentionHours: 168,
+      deadLetterTopic: 'nlx.telemetry.asset.v1.dlq',
+    });
+
+    const mqttContract = BrokerTopicContractSchema.parse({
+      backend: 'mqtt-sparkplug',
+      topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'sparkplug.telemetry.v1',
+      compatibility: 'backward',
+      qos: 'at-least-once',
+    });
+
+    const result = validateTopicAgainstContract(mqttContract, kafkaRegistration);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.includes('Backend mismatch'))).toBe(true);
+  });
+
+  it('detects compatibility issues for breaking payload changes without major bump', () => {
+    const contract = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.telemetry.asset.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'telemetry.asset.v1',
+      compatibility: 'full',
+      partitions: 12,
+      retentionHours: 168,
+      deadLetterTopic: 'nlx.telemetry.asset.v1.dlq',
+    });
+
+    const breakingRegistration = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.telemetry.asset.v1',
+      version: { major: 1, minor: 1, patch: 0 },
+      payloadSchemaId: 'telemetry.asset.v2',
+      compatibility: 'full',
+      partitions: 12,
+      retentionHours: 168,
+      deadLetterTopic: 'nlx.telemetry.asset.v1.dlq',
+    });
+
+    const result = validateTopicAgainstContract(contract, breakingRegistration);
+
+    expect(result.valid).toBe(false);
+    expect(result.compatibility?.compatible).toBe(false);
+    expect(result.issues.some((issue) => issue.includes('major version bump'))).toBe(true);
+  });
+
+  it('detects Sparkplug QoS mismatches against the expected contract', () => {
+    const contract = BrokerTopicContractSchema.parse({
+      backend: 'mqtt-sparkplug',
+      topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'sparkplug.telemetry.v1',
+      compatibility: 'backward',
+      qos: 'at-least-once',
+    });
+
+    const registration = BrokerTopicContractSchema.parse({
+      backend: 'mqtt-sparkplug',
+      topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'sparkplug.telemetry.v1',
+      compatibility: 'backward',
+      qos: 'exactly-once',
+    });
+
+    const result = validateTopicAgainstContract(contract, registration);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.includes('QoS mismatch'))).toBe(true);
+  });
+
+  it('returns schema violation issues for malformed registration payloads', () => {
+    const malformed = {
+      backend: 'kafka-redpanda',
+      topic: 'nlx.telemetry.asset.v1',
+    } as unknown as Parameters<typeof validateTopicRegistrationAgainstContracts>[0];
+
+    const result: TopicValidationResult = validateTopicRegistrationAgainstContracts(malformed);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]).toContain('Registration schema violation');
+  });
+
+  it('classifies telemetry and sparkplug topics as safety critical', () => {
+    expect(isSafetyCriticalTopic({ topic: 'nlx.telemetry.asset.v1' })).toBe(true);
+    expect(isSafetyCriticalTopic({ topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01' })).toBe(true);
+    expect(isSafetyCriticalTopic({ topic: 'nlx.api.federation.v1' })).toBe(false);
+  });
+
+  it('fails hard for T1 sites when a safety-critical topic violates governance', () => {
+    const violatingRegistration = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.telemetry.asset.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'telemetry.asset.v1',
+      compatibility: 'full',
+      partitions: 3,
+      retentionHours: 168,
+      deadLetterTopic: 'nlx.telemetry.asset.v1.dlq',
+    });
+
+    const result = validateTopicRegistryGuard([violatingRegistration], {
+      tier: SITE_TIER.T1,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.errors[0]?.issues.some((issue) => issue.includes('Partitions mismatch'))).toBe(true);
+    expect(() =>
+      assertTopicRegistryGuard([violatingRegistration], {
+        tier: SITE_TIER.T1,
+      })
+    ).toThrow('Broker topic governance failed bootstrap validation');
+  });
+
+  it('warns for T2/T3 non-critical topic violations by default policy', () => {
+    const violatingApiRegistration = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.api.federation.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'api.federation.v1',
+      compatibility: 'backward',
+      partitions: 3,
+      retentionHours: 72,
+    });
+
+    const t2Result = validateTopicRegistryGuard([violatingApiRegistration], {
+      tier: SITE_TIER.T2,
+    });
+    const t3Result = validateTopicRegistryGuard([violatingApiRegistration], {
+      tier: SITE_TIER.T3,
+    });
+
+    expect(t2Result.valid).toBe(true);
+    expect(t2Result.errors).toHaveLength(0);
+    expect(t2Result.warnings).toHaveLength(1);
+
+    expect(t3Result.valid).toBe(true);
+    expect(t3Result.errors).toHaveLength(0);
+    expect(t3Result.warnings).toHaveLength(1);
+  });
+
+  it('passes guard validation for conformant registrations and does not throw', () => {
+    const conformant = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.api.federation.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'api.federation.v1',
+      compatibility: 'backward',
+      partitions: 3,
+      retentionHours: 24,
+    });
+
+    const result = validateTopicRegistryGuard([conformant], {
+      tier: SITE_TIER.T1,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(() =>
+      assertTopicRegistryGuard([conformant], {
+        tier: SITE_TIER.T1,
+      })
+    ).not.toThrow();
+  });
+
+  it('supports tier policy overrides to escalate warnings to errors on T2', () => {
+    const violatingApiRegistration = BrokerTopicContractSchema.parse({
+      backend: 'kafka-redpanda',
+      topic: 'nlx.api.federation.v1',
+      version: { major: 1, minor: 0, patch: 0 },
+      payloadSchemaId: 'api.federation.v1',
+      compatibility: 'backward',
+      partitions: 3,
+      retentionHours: 72,
+    });
+
+    const result = validateTopicRegistryGuard([violatingApiRegistration], {
+      tier: SITE_TIER.T2,
+      tierPolicy: {
+        [SITE_TIER.T2]: 'error',
+      },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/packages/schemas/src/broker/governance.ts
+++ b/packages/schemas/src/broker/governance.ts
@@ -1,0 +1,215 @@
+import { SITE_TIER, type SiteTier } from '../federation/index';
+import {
+  BROKER_TOPIC_CONTRACTS,
+  BrokerTopicContractSchema,
+  evaluateTopicContractCompatibility,
+  type BrokerBackend,
+  type BrokerTopicContract,
+  type TopicCompatibilityResult,
+} from './index';
+
+/**
+ * Broker governance bootstrap pattern.
+ *
+ * Services register their producer/subscriber topics at startup and run these
+ * validations before opening broker connections. This keeps runtime behavior
+ * model-aligned by enforcing conformance with `BROKER_TOPIC_CONTRACTS`.
+ */
+
+export interface TopicValidationResult {
+  valid: boolean;
+  issues: string[];
+  contract?: BrokerTopicContract;
+  compatibility?: TopicCompatibilityResult;
+}
+
+export type GovernanceSeverity = 'error' | 'warning';
+
+export interface TopicRegistryViolation {
+  backend: BrokerBackend;
+  topic: string;
+  severity: GovernanceSeverity;
+  issues: string[];
+}
+
+export interface TopicRegistryGuardResult {
+  valid: boolean;
+  errors: TopicRegistryViolation[];
+  warnings: TopicRegistryViolation[];
+}
+
+export interface TopicRegistryGuardOptions {
+  tier: SiteTier;
+  contracts?: readonly BrokerTopicContract[];
+  tierPolicy?: Partial<Record<SiteTier, GovernanceSeverity>>;
+}
+
+const DEFAULT_TIER_POLICY: Record<SiteTier, GovernanceSeverity> = {
+  [SITE_TIER.T1]: 'error',
+  [SITE_TIER.T2]: 'warning',
+  [SITE_TIER.T3]: 'warning',
+};
+
+const SAFETY_CRITICAL_TOPIC_PATTERNS = [
+  /^spBv1\.0\//,
+  /^nlx\.telemetry\./,
+  /^nlx\.intents\./,
+  /^nlx\.recipes\./,
+];
+
+function formatSchemaIssues(prefix: string, issues: { path: (string | number)[]; message: string }[]): string[] {
+  return issues.map((issue) => {
+    const path = issue.path.length > 0 ? ` at ${issue.path.join('.')}` : '';
+    return `${prefix}${path}: ${issue.message}`;
+  });
+}
+
+export function isSafetyCriticalTopic(topic: Pick<BrokerTopicContract, 'topic'>): boolean {
+  return SAFETY_CRITICAL_TOPIC_PATTERNS.some((pattern) => pattern.test(topic.topic));
+}
+
+export function validateTopicAgainstContract(
+  contract: BrokerTopicContract,
+  registration: BrokerTopicContract
+): TopicValidationResult {
+  const issues: string[] = [];
+
+  if (contract.topic !== registration.topic) {
+    issues.push(
+      `Topic mismatch. Registration ${registration.topic} does not match contract topic ${contract.topic}.`
+    );
+  }
+
+  if (contract.backend !== registration.backend) {
+    issues.push(
+      `Backend mismatch. Registration backend ${registration.backend} does not match contract backend ${contract.backend}.`
+    );
+  }
+
+  if (contract.backend === 'mqtt-sparkplug' && registration.backend === 'mqtt-sparkplug') {
+    if (contract.qos !== registration.qos) {
+      issues.push(`QoS mismatch. Expected ${contract.qos}, received ${registration.qos}.`);
+    }
+  }
+
+  if (contract.backend === 'kafka-redpanda' && registration.backend === 'kafka-redpanda') {
+    if (contract.partitions !== registration.partitions) {
+      issues.push(
+        `Partitions mismatch. Expected ${contract.partitions}, received ${registration.partitions}.`
+      );
+    }
+
+    if (contract.retentionHours !== registration.retentionHours) {
+      issues.push(
+        `Retention mismatch. Expected ${contract.retentionHours}h, received ${registration.retentionHours}h.`
+      );
+    }
+
+    if (contract.deadLetterTopic !== registration.deadLetterTopic) {
+      issues.push(
+        `Dead-letter topic mismatch. Expected ${contract.deadLetterTopic ?? 'none'}, received ${registration.deadLetterTopic ?? 'none'}.`
+      );
+    }
+  }
+
+  const compatibility = evaluateTopicContractCompatibility(contract, registration);
+  if (!compatibility.compatible) {
+    issues.push(compatibility.reason);
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    contract,
+    compatibility,
+  };
+}
+
+export function validateTopicRegistrationAgainstContracts(
+  registration: BrokerTopicContract,
+  contracts: readonly BrokerTopicContract[] = BROKER_TOPIC_CONTRACTS
+): TopicValidationResult {
+  const registrationParse = BrokerTopicContractSchema.safeParse(registration);
+  if (!registrationParse.success) {
+    return {
+      valid: false,
+      issues: formatSchemaIssues('Registration schema violation', registrationParse.error.issues),
+    };
+  }
+
+  const normalized = registrationParse.data;
+  const contract = contracts.find((candidate) => candidate.topic === normalized.topic);
+
+  if (!contract) {
+    return {
+      valid: false,
+      issues: [
+        `No broker topic contract found for topic ${normalized.topic}. Add the topic to BROKER_TOPIC_CONTRACTS before bootstrap.`,
+      ],
+    };
+  }
+
+  return validateTopicAgainstContract(contract, normalized);
+}
+
+export function validateTopicRegistryGuard(
+  registrations: readonly BrokerTopicContract[],
+  options: TopicRegistryGuardOptions
+): TopicRegistryGuardResult {
+  const contracts = options.contracts ?? BROKER_TOPIC_CONTRACTS;
+  const policy: Record<SiteTier, GovernanceSeverity> = {
+    ...DEFAULT_TIER_POLICY,
+    ...(options.tierPolicy ?? {}),
+  };
+
+  const errors: TopicRegistryViolation[] = [];
+  const warnings: TopicRegistryViolation[] = [];
+
+  for (const registration of registrations) {
+    const validation = validateTopicRegistrationAgainstContracts(registration, contracts);
+    if (validation.valid) {
+      continue;
+    }
+
+    const severity: GovernanceSeverity =
+      options.tier === SITE_TIER.T1 && isSafetyCriticalTopic(registration)
+        ? 'error'
+        : policy[options.tier];
+
+    const violation: TopicRegistryViolation = {
+      backend: registration.backend,
+      topic: registration.topic,
+      severity,
+      issues: validation.issues,
+    };
+
+    if (severity === 'error') {
+      errors.push(violation);
+    } else {
+      warnings.push(violation);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+export function assertTopicRegistryGuard(
+  registrations: readonly BrokerTopicContract[],
+  options: TopicRegistryGuardOptions
+): void {
+  const result = validateTopicRegistryGuard(registrations, options);
+
+  if (!result.valid) {
+    const issueSummary = result.errors
+      .map((violation) => `${violation.backend}:${violation.topic} -> ${violation.issues.join('; ')}`)
+      .join(' | ');
+
+    throw new Error(
+      `Broker topic governance failed bootstrap validation with ${result.errors.length} error(s): ${issueSummary}`
+    );
+  }
+}

--- a/packages/schemas/src/broker/index.ts
+++ b/packages/schemas/src/broker/index.ts
@@ -55,6 +55,62 @@ export const BrokerTopicContractSchema = z.discriminatedUnion('backend', [
 ]);
 export type BrokerTopicContract = z.infer<typeof BrokerTopicContractSchema>;
 
+/**
+ * Canonical broker topic contracts for Phase 1 governance checks.
+ *
+ * These contracts are the runtime source of truth used by bootstrap validators
+ * to detect producer/subscriber drift before services begin message flow.
+ */
+export const BROKER_TOPIC_CONTRACTS: readonly BrokerTopicContract[] = [
+  BrokerTopicContractSchema.parse({
+    backend: 'kafka-redpanda',
+    topic: 'nlx.telemetry.asset.v1',
+    version: { major: 1, minor: 0, patch: 0 },
+    payloadSchemaId: 'telemetry.asset.v1',
+    compatibility: 'full',
+    partitions: 12,
+    retentionHours: 168,
+    deadLetterTopic: 'nlx.telemetry.asset.v1.dlq',
+  }),
+  BrokerTopicContractSchema.parse({
+    backend: 'kafka-redpanda',
+    topic: 'nlx.intents.commands.v1',
+    version: { major: 1, minor: 0, patch: 0 },
+    payloadSchemaId: 'intents.commands.v1',
+    compatibility: 'backward',
+    partitions: 6,
+    retentionHours: 72,
+    deadLetterTopic: 'nlx.intents.commands.v1.dlq',
+  }),
+  BrokerTopicContractSchema.parse({
+    backend: 'kafka-redpanda',
+    topic: 'nlx.recipes.execution.v1',
+    version: { major: 1, minor: 0, patch: 0 },
+    payloadSchemaId: 'recipes.execution.v1',
+    compatibility: 'backward',
+    partitions: 6,
+    retentionHours: 168,
+    deadLetterTopic: 'nlx.recipes.execution.v1.dlq',
+  }),
+  BrokerTopicContractSchema.parse({
+    backend: 'kafka-redpanda',
+    topic: 'nlx.api.federation.v1',
+    version: { major: 1, minor: 0, patch: 0 },
+    payloadSchemaId: 'api.federation.v1',
+    compatibility: 'backward',
+    partitions: 3,
+    retentionHours: 24,
+  }),
+  BrokerTopicContractSchema.parse({
+    backend: 'mqtt-sparkplug',
+    topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+    version: { major: 1, minor: 0, patch: 0 },
+    payloadSchemaId: 'sparkplug.telemetry.v1',
+    compatibility: 'backward',
+    qos: 'at-least-once',
+  }),
+];
+
 export const BrokerAclRuleSchema = z
   .object({
     principal: z

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -12,6 +12,7 @@ export * from './federation/index.js';
 export * from './feature-flags/index.js';
 export * from './sparkplug/index.js';
 export * from './broker/index.js';
+export * from './broker/governance.js';
 export * from './intents/index.js';
 export * from './recipes/index.js';
 export * from './assets/index.js';


### PR DESCRIPTION
## Summary
- add canonical BROKER_TOPIC_CONTRACTS registry for bootstrap governance checks
- add broker governance runtime utilities (alidateTopicAgainstContract, registry validation, tiered guard, assert helper)
- add focused governance test suite covering contract conformance, mismatch detection, compatibility failures, and tier policy behavior
- export governance utilities from package root for consistent reuse

## Validation
- npm run test --workspace @neurologix/schemas -- src/broker/governance.test.ts --coverage
- npm run lint --workspace @neurologix/schemas
- npm run type-check --workspace @neurologix/schemas
- npm run lint
- npm run type-check
- npm run test -- -- --coverage

Closes #103