### PR TITLE
ci(#105): enforce per-package coverage thresholds in vitest configs

### DIFF
--- a/apps/mission-control/vitest.config.ts
+++ b/apps/mission-control/vitest.config.ts
@@ -17,12 +17,10 @@ export default defineConfig({
         'src/index.ts', // barrel re-export; no testable logic
       ],
       thresholds: {
-        global: {
-          branches: 70, // SSE and 500-path error branches are infrastructure code
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
+        branches: 70, // SSE and 500-path error branches are infrastructure code
+        functions: 80,
+        lines: 80,
+        statements: 80,
       },
     },
   },

--- a/packages/adapters/vitest.config.ts
+++ b/packages/adapters/vitest.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 85,
+        branches: 70,
+        functions: 85,
+        lines: 85,
+      },
     },
   },
   resolve: {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,6 +5,17 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 90,
+        lines: 95,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/packages/schemas/vitest.config.ts
+++ b/packages/schemas/vitest.config.ts
@@ -5,6 +5,17 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 95,
+        lines: 95,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/packages/security-core/package.json
+++ b/packages/security-core/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsc --build",
     "lint": "eslint src --ext .ts",
-    "test": "vitest --config vitest.config.ts"
+    "test": "vitest --config vitest.config.ts",
+    "test:ci": "vitest run --coverage --config vitest.config.ts"
   },
   "dependencies": {
     "crypto": "^1.0.1"

--- a/packages/security-core/vitest.config.ts
+++ b/packages/security-core/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 75,
+        branches: 75,
+        functions: 80,
+        lines: 75,
+      },
     },
   },
 });

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -5,6 +5,17 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 95,
+        branches: 75,
+        functions: 65,
+        lines: 95,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/services/capability-registry/vitest.config.ts
+++ b/services/capability-registry/vitest.config.ts
@@ -5,6 +5,17 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 90,
+        branches: 80,
+        functions: 80,
+        lines: 90,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/services/digital-twin/package.json
+++ b/services/digital-twin/package.json
@@ -15,6 +15,7 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "test": "vitest run",
+    "test:ci": "vitest run --coverage",
     "test:watch": "vitest",
     "type-check": "tsc --build --force --pretty false",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"

--- a/services/digital-twin/vitest.config.ts
+++ b/services/digital-twin/vitest.config.ts
@@ -7,7 +7,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 80,
+        branches: 70,
+        functions: 80,
+        lines: 80,
+      },
     },
   },
 });

--- a/services/policy-engine/package.json
+++ b/services/policy-engine/package.json
@@ -15,6 +15,7 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "test": "vitest run",
+    "test:ci": "vitest run --coverage",
     "test:watch": "vitest",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },

--- a/services/policy-engine/vitest.config.ts
+++ b/services/policy-engine/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'dist/', '**/*.d.ts', '**/*.test.ts', 'vitest.config.ts'],
+      thresholds: {
+        statements: 90,
+        branches: 80,
+        functions: 95,
+        lines: 90,
+      },
     },
   },
   resolve: {

--- a/services/recipe-executor/package.json
+++ b/services/recipe-executor/package.json
@@ -15,6 +15,7 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "test": "vitest run",
+    "test:ci": "vitest run --coverage",
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"

--- a/services/recipe-executor/vitest.config.ts
+++ b/services/recipe-executor/vitest.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', '**/*.config.ts'],
+      thresholds: {
+        statements: 75,
+        branches: 70,
+        functions: 85,
+        lines: 75,
+      },
     },
   },
   resolve: {

--- a/services/site-registry/vitest.config.ts
+++ b/services/site-registry/vitest.config.ts
@@ -10,12 +10,10 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts', 'vitest.config.ts'],
       thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,12 +10,10 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/**', 'dist/**', '**/*.d.ts', '**/*.config.*', '**/coverage/**'],
       thresholds: {
-        global: {
-          branches: 90,
-          functions: 90,
-          lines: 90,
-          statements: 90,
-        },
+        branches: 90,
+        functions: 90,
+        lines: 90,
+        statements: 90,
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes #105

Adds coverage threshold enforcement to all 11 packages/services in the monorepo. Previously, 9 of 11 were missing enforcement and 4 services were not participating in the \	est:ci\ turbo pipeline at all.

## Problem solved

- **CI coverage gate gap**: Coverage was collected (artifacts uploaded) but never enforced — CI never failed on insufficient coverage, violating the ≥90% core module / ≥80% overall mandate
- **Wrong threshold API**: The existing \	hresholds.global\ wrapper in site-registry and mission-control was **silently ignored** in vitest v3 (the flat \	hresholds\ structure is required); this PR fixes all configs
- **Missing test:ci scripts**: \digital-twin\, \policy-engine\, \ecipe-executor\, and \security-core\ had no \	est:ci\ script, so they were excluded from the turbo CI pipeline entirely

## Changes

### Coverage thresholds added (vitest v3 flat syntax)
| Package | Stmts | Branch | Funcs | Lines |
|---------|-------|--------|-------|-------|
| packages/core | 95% | 90% | 90% | 95% |
| packages/schemas | 95% | 90% | 95% | 95% |
| packages/adapters | 85% | 70% | 85% | 85% |
| packages/security-core | 75% | 75% | 80% | 75% |
| packages/ui | 95% | 75% | 65% | 95% |
| services/capability-registry | 90% | 80% | 80% | 90% |
| services/digital-twin | 80% | 70% | 80% | 80% |
| services/policy-engine | 90% | 80% | 95% | 90% |
| services/recipe-executor | 75% | 70% | 85% | 75% |

### Bug fixes
- Fixed \	hresholds.global\ → flat \	hresholds\ in site-registry, mission-control, and root vitest.config.ts (all were previously non-enforcing)
- Added \**/*.config.ts\ to coverage excludes where missing (prevents vitest.config.ts diluting coverage metrics)

### test:ci scripts added
- \packages/security-core\: \itest run --coverage --config vitest.config.ts\
- \services/digital-twin\: \itest run --coverage\
- \services/policy-engine\: \itest run --coverage\
- \services/recipe-executor\: \itest run --coverage\

## Validation

- ✅ \
px turbo run test:ci --force\: **17/17 tasks successful** (previously 13/13; 4 new services now in pipeline)
- ✅ No coverage threshold errors
- ✅ lint: 14/14 tasks successful
- ✅ typecheck: 16/16 tasks successful
- ✅ Threshold enforcement verified: \EXIT=1\ confirmed when threshold exceeded (tested with adapters at 85% threshold vs 84% coverage before exclude fix)

## Phase alignment

Phase 1 CI-hardening. All thresholds set at current baseline (regression guards), not aspirational targets.