### PR TITLE
docs(#107): align customer/developer packets with CI docs gate

### DIFF
--- a/.customer/ACCOUNTS.md
+++ b/.customer/ACCOUNTS.md
@@ -1,0 +1,19 @@
+# Account Management
+
+## Roles
+
+- **Customer Admin:** Manages users, permissions, and site-level settings.
+- **Operator:** Executes approved workflows and monitors live operations.
+- **Auditor:** Reviews logs, reports, and policy decisions.
+
+## Account Lifecycle
+
+1. Customer Admin requests user creation.
+2. User receives onboarding instructions.
+3. Role assignment is validated against least-privilege policy.
+4. Access is reviewed periodically and removed when no longer needed.
+
+## Security Notes
+
+- Enforce strong authentication and role-based access.
+- Remove dormant accounts as part of routine governance.

--- a/.customer/BILLING.md
+++ b/.customer/BILLING.md
@@ -1,0 +1,15 @@
+# Billing Overview
+
+## Billing Model
+
+Billing terms and schedules are defined by your executed commercial agreement.
+
+## Monthly Review Inputs
+
+- Active sites and enabled modules
+- Agreed support tier
+- Optional professional services usage
+
+## Support
+
+For billing inquiries, contact your account representative using your contracted support channel.

--- a/.customer/CHANGELOG.md
+++ b/.customer/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Customer Changelog
+
+## 2026-03-10
+
+- Added initial customer documentation packet baseline.
+- Added CI validation gate for required customer/developer packet files.

--- a/.customer/FAQ.md
+++ b/.customer/FAQ.md
@@ -1,0 +1,17 @@
+# Frequently Asked Questions
+
+## Does NeuroLogix bypass safety interlocks?
+
+No. Control actions must pass validated recipes and safety controls.
+
+## Where can we review activity history?
+
+Use audit views and exported reports from Mission Control.
+
+## How do we roll out changes safely?
+
+Use staged rollout gates and validate in non-production before production rollout.
+
+## How do we request help?
+
+Use your contracted support and escalation channels.

--- a/.customer/OPERATIONS.md
+++ b/.customer/OPERATIONS.md
@@ -1,0 +1,19 @@
+# Daily Operations
+
+## Operational Checklist
+
+- Confirm Mission Control health indicators are green.
+- Review active alerts and acknowledgements.
+- Verify planned recipe windows and operator staffing.
+- Monitor command latency and recipe success metrics.
+
+## Incident Handling
+
+1. Shift to approved safe/manual mode if risk is detected.
+2. Follow your incident communication protocol.
+3. Capture timeline and evidence for audit review.
+4. Coordinate with support using your escalation runbook.
+
+## Escalation
+
+Use contracted support channels for priority incidents and include site ID, timeline, and observed impact.

--- a/.customer/README.md
+++ b/.customer/README.md
@@ -1,0 +1,18 @@
+# NeuroLogix Customer Packet
+
+This folder contains customer-facing guidance for onboarding, daily operations, and support.
+
+## Included Guides
+
+- [Setup](./SETUP.md)
+- [Accounts](./ACCOUNTS.md)
+- [Billing](./BILLING.md)
+- [Operations](./OPERATIONS.md)
+- [FAQ](./FAQ.md)
+- [Roadmap](./TODO.md)
+- [Changelog](./CHANGELOG.md)
+- [Security](./SECURITY.md)
+
+## Scope
+
+These documents are written for operators, customer admins, and implementation stakeholders.

--- a/.customer/SECURITY.md
+++ b/.customer/SECURITY.md
@@ -1,0 +1,16 @@
+# Security
+
+## Reporting Security Concerns
+
+Report security concerns through your contracted support and security contact channels.
+
+Include:
+
+- Environment and site context
+- Steps to reproduce
+- Impact and observed behavior
+- Logs or evidence that do not expose secrets
+
+## Security Posture Summary
+
+NeuroLogix is built with safety-first controls, auditability, and industrial security alignment (including IEC 62443 direction) as core principles.

--- a/.customer/SETUP.md
+++ b/.customer/SETUP.md
@@ -1,0 +1,20 @@
+# Customer Setup Guide
+
+## Prerequisites
+
+- Provisioned NeuroLogix environment
+- Customer administrator account
+- Approved network and browser access to Mission Control
+
+## Initial Steps
+
+1. Confirm site and tenant identifiers provided by your implementation team.
+2. Sign in to Mission Control with your administrator credentials.
+3. Verify line topology, equipment map, and policy defaults.
+4. Confirm alert contacts and escalation channels.
+
+## Go-Live Checks
+
+- Verify safety policy defaults are loaded.
+- Confirm audit logging is visible in dashboard and exports.
+- Execute a controlled non-production recipe test.

--- a/.customer/TODO.md
+++ b/.customer/TODO.md
@@ -1,0 +1,15 @@
+# Customer-Facing Roadmap
+
+## In Progress
+
+- Data Spine & Contracts hardening
+- CI/CD governance and release safety gates
+
+## Planned
+
+- Expanded configuration UX for multi-site controls
+- Additional operational reporting templates
+
+## Notes
+
+Roadmap details are subject to contract scope, safety review, and rollout readiness.

--- a/.developer/ARCHITECTURE.md
+++ b/.developer/ARCHITECTURE.md
@@ -1,0 +1,14 @@
+# Developer Architecture Notes
+
+## Canonical Sources
+
+- System model: `.github/.system-state/model/system_state_model.yaml`
+- Federation model: `.github/.system-state/model/federation_model.yaml`
+- Contracts: `.github/.system-state/contracts/`
+- ADRs: `docs/architecture/ADR-*.md`
+
+## Delivery Principles
+
+- Model-first: update models before implementation changes.
+- Safety-first: no direct PLC actuation outside validated recipe execution.
+- Determinism-first: prefer single canonical patterns over variants.

--- a/.developer/DECISIONS/README.md
+++ b/.developer/DECISIONS/README.md
@@ -1,0 +1,5 @@
+# Architecture Decisions Index
+
+Use this directory for internal decision records that support delivery and operations.
+
+Canonical ADRs currently live in `docs/architecture/`.

--- a/.developer/INCIDENTS.md
+++ b/.developer/INCIDENTS.md
@@ -1,0 +1,12 @@
+# Incident Log
+
+Track notable incidents with:
+
+- timestamp
+- impacted services/sites
+- symptom summary
+- mitigation steps
+- root-cause notes
+- follow-up actions
+
+Use linked runbooks and PRs/issues for durable traceability.

--- a/.developer/README.md
+++ b/.developer/README.md
@@ -1,0 +1,13 @@
+# Developer Packet
+
+This folder contains internal engineering references for development, release, operations, and security.
+
+## Included Guides
+
+- [Technical TODO](./TODO.md)
+- [Architecture](./ARCHITECTURE.md)
+- [Decisions](./DECISIONS/README.md)
+- [Runbooks](./RUNBOOKS/)
+- [Release](./RELEASE.md)
+- [Incidents](./INCIDENTS.md)
+- [Security Internal](./SECURITY_INTERNAL.md)

--- a/.developer/RELEASE.md
+++ b/.developer/RELEASE.md
@@ -1,0 +1,12 @@
+# Release Process
+
+## Baseline Flow
+
+1. Merge validated PRs to `main`.
+2. Ensure required CI checks pass.
+3. Run release workflow with explicit production input gate.
+4. Monitor rollout and rollback triggers.
+
+## Evidence
+
+Record release outcomes in planning artifacts and GitHub workflow history.

--- a/.developer/SECURITY_INTERNAL.md
+++ b/.developer/SECURITY_INTERNAL.md
@@ -1,0 +1,13 @@
+# Internal Security Notes
+
+## Security Baseline
+
+- No hardcoded secrets in repository code or docs.
+- Follow least privilege for service and operator access.
+- Preserve immutable audit trail guarantees.
+
+## Operational Security
+
+- Treat safety-critical paths as high-risk changes.
+- Validate security-sensitive changes with focused review and CI evidence.
+- Record incidents and mitigations in `.developer/INCIDENTS.md`.

--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -1,0 +1,12 @@
+# Developer TODO
+
+## Near Term
+
+- Expand contract tests for broker and federation boundaries.
+- Continue CI/CD hardening for release and rollback evidence.
+- Close documentation alignment gaps as they are identified.
+
+## Quality Targets
+
+- Keep CI green on `main`.
+- Preserve coverage thresholds and model-first validation gates.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Validate system-state model
         run: npm run validate:model:system-state
 
+      - name: Validate documentation packets
+        run: npm run validate:doc-packets
+
   # ─────────────────────────
   # Lint
   # ─────────────────────────

--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ docker compose logs -f capability-registry
 
 ## 📋 Development Phases
 
+## 📚 Documentation Packets
+
+- **Customer-facing packet:** [`.customer/`](./.customer/)
+- **Developer packet:** [`.developer/`](./.developer/)
+
 ### ✅ Phase 0 — Foundations (Current)
 
 - [x] Monorepo structure with Turbo

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "type-check": "turbo run type-check",
     "clean": "turbo run clean && rm -rf node_modules",
     "validate:model:system-state": "node -e \"const fs=require('fs'); const file='.github/.system-state/model/federation_model.yaml'; if(!fs.existsSync(file)){ console.error('ERROR: Missing required system-state model file: '+file); process.exit(1);}\"",
+    "validate:doc-packets": "node scripts/validate-doc-packets.js",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,yaml,yml}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md,yaml,yml}\"",
     "security:audit": "npm audit && turbo run security:audit",

--- a/scripts/validate-doc-packets.js
+++ b/scripts/validate-doc-packets.js
@@ -1,0 +1,65 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const requiredEntries = [
+  { path: '.customer/README.md', type: 'file' },
+  { path: '.customer/SETUP.md', type: 'file' },
+  { path: '.customer/ACCOUNTS.md', type: 'file' },
+  { path: '.customer/BILLING.md', type: 'file' },
+  { path: '.customer/OPERATIONS.md', type: 'file' },
+  { path: '.customer/FAQ.md', type: 'file' },
+  { path: '.customer/TODO.md', type: 'file' },
+  { path: '.customer/CHANGELOG.md', type: 'file' },
+  { path: '.customer/SECURITY.md', type: 'file' },
+  { path: '.developer/README.md', type: 'file' },
+  { path: '.developer/TODO.md', type: 'file' },
+  { path: '.developer/ARCHITECTURE.md', type: 'file' },
+  { path: '.developer/DECISIONS', type: 'directory' },
+  { path: '.developer/RUNBOOKS', type: 'directory' },
+  { path: '.developer/RELEASE.md', type: 'file' },
+  { path: '.developer/INCIDENTS.md', type: 'file' },
+  { path: '.developer/SECURITY_INTERNAL.md', type: 'file' }
+];
+
+const missing = [];
+const wrongType = [];
+
+for (const entry of requiredEntries) {
+  const absolutePath = path.resolve(process.cwd(), entry.path);
+
+  if (!fs.existsSync(absolutePath)) {
+    missing.push(entry.path);
+    continue;
+  }
+
+  const stats = fs.statSync(absolutePath);
+  const isExpectedType =
+    (entry.type === 'file' && stats.isFile()) ||
+    (entry.type === 'directory' && stats.isDirectory());
+
+  if (!isExpectedType) {
+    wrongType.push(`${entry.path} (expected ${entry.type})`);
+  }
+}
+
+if (missing.length > 0 || wrongType.length > 0) {
+  console.error('Documentation packet validation failed.');
+
+  if (missing.length > 0) {
+    console.error('Missing required paths:');
+    for (const filePath of missing) {
+      console.error(`- ${filePath}`);
+    }
+  }
+
+  if (wrongType.length > 0) {
+    console.error('Paths with incorrect type:');
+    for (const filePath of wrongType) {
+      console.error(`- ${filePath}`);
+    }
+  }
+
+  process.exit(1);
+}
+
+console.log('Documentation packet validation passed.');


### PR DESCRIPTION
## Summary
- add required `.customer/` packet baseline files
- add missing `.developer/` packet baseline files (`README`, `TODO`, `ARCHITECTURE`, `DECISIONS`, `RELEASE`, `INCIDENTS`, `SECURITY_INTERNAL`)
- add `validate:doc-packets` script and wire it into CI `model-state` gate
- add packet links in root README

## Problem
Issue #107 identified policy drift: `.customer/` was absent and `.developer/` only had `RUNBOOKS/`, with no CI guard.

## Validation
- `npm run validate:doc-packets`
- `npm run lint`
- `npm run type-check`

Closes #107