### PR TITLE
feat(#115): add broker ACL runtime authorization and bootstrap coverage guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ docker compose logs -f capability-registry
 - [x] Broker topic governance — runtime enforcement via `BrokerTopicValidator` and `TopicGovernanceRegistry` (#103)
 - [x] Contract testing framework — server contract baselines for site-registry (#109) and mission-control (#113); `npm run test:contracts:servers` CI gate active
 - [ ] Message broker setup (MQTT + Kafka) — Sparkplug schema defined; runtime broker wiring pending
-- [ ] Topic ACLs & security
+- [x] Topic ACLs & security — runtime ACL authorization + bootstrap coverage guard in `packages/schemas/src/broker/acl.ts` (#115)
 
 ### ✅ Phase 2 — Core Runtime
 

--- a/docs/architecture/phase-1-topic-governance.md
+++ b/docs/architecture/phase-1-topic-governance.md
@@ -42,6 +42,10 @@ compatibility policy.
 - Backend-specific topic pattern guards:
   - Sparkplug ACL patterns must start with `spBv1.0/`
   - Kafka/Redpanda ACL patterns must start with `nlx.`
+- Runtime authorization path: `authorizeBrokerTopicAccess` in
+  `packages/schemas/src/broker/acl.ts`
+- Bootstrap coverage gate: `assertBrokerAclCoverage` for startup-time validation
+  that each required registration is covered by at least one ACL rule
 
 ## Partitioning, Retention, and Dead-Letter Strategy
 

--- a/packages/schemas/src/broker/acl.test.ts
+++ b/packages/schemas/src/broker/acl.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertBrokerAclCoverage,
+  authorizeBrokerTopicAccess,
+  validateBrokerAclCoverage,
+  type BrokerAclAuthorizationRequest,
+} from '@/broker/acl';
+import type { BrokerAclRule } from '@/broker/index';
+
+const BASE_RULES: readonly BrokerAclRule[] = [
+  {
+    principal: 'svc.recipe-executor',
+    backend: 'kafka-redpanda',
+    operation: 'publish',
+    topicPattern: 'nlx.recipes.execution.*',
+  },
+  {
+    principal: 'svc.digital-twin',
+    backend: 'kafka-redpanda',
+    operation: 'subscribe',
+    topicPattern: 'nlx.telemetry.asset.v1',
+  },
+  {
+    principal: 'svc.digital-twin',
+    backend: 'mqtt-sparkplug',
+    operation: 'subscribe',
+    topicPattern: 'spBv1.0/line-a/DDATA/+/#',
+  },
+];
+
+describe('Broker ACL Runtime Guard', () => {
+  it('denies malformed authorization requests before evaluating ACL rules', () => {
+    const malformedRequest = {
+      principal: 'recipe-executor',
+      backend: 'kafka-redpanda',
+      operation: 'publish',
+      topic: 'nlx.recipes.execution.v1',
+    } as unknown as BrokerAclAuthorizationRequest;
+
+    const decision = authorizeBrokerTopicAccess(malformedRequest, BASE_RULES);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('Authorization request schema violation');
+  });
+
+  it('authorizes Kafka publish access when wildcard pattern matches one segment', () => {
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.recipe-executor',
+      backend: 'kafka-redpanda',
+      operation: 'publish',
+      topic: 'nlx.recipes.execution.v1',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, BASE_RULES);
+
+    expect(decision.authorized).toBe(true);
+    expect(decision.matchedRule?.topicPattern).toBe('nlx.recipes.execution.*');
+  });
+
+  it('denies access when operation differs from ACL rule', () => {
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.recipe-executor',
+      backend: 'kafka-redpanda',
+      operation: 'subscribe',
+      topic: 'nlx.recipes.execution.v1',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, BASE_RULES);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('No ACL rule matched');
+  });
+
+  it('denies Kafka topics when wildcard does not match segment count', () => {
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.recipe-executor',
+      backend: 'kafka-redpanda',
+      operation: 'publish',
+      topic: 'nlx.recipes.execution.v1.dlq',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, BASE_RULES);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('No ACL rule matched');
+  });
+
+  it('authorizes Sparkplug subscribe access with + and # wildcard matching', () => {
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.digital-twin',
+      backend: 'mqtt-sparkplug',
+      operation: 'subscribe',
+      topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, BASE_RULES);
+
+    expect(decision.authorized).toBe(true);
+    expect(decision.matchedRule?.topicPattern).toBe('spBv1.0/line-a/DDATA/+/#');
+  });
+
+  it('denies invalid backend topic combinations before ACL matching', () => {
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.digital-twin',
+      backend: 'kafka-redpanda',
+      operation: 'subscribe',
+      topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, BASE_RULES);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('Invalid Kafka/Redpanda topic');
+  });
+
+  it('denies invalid Sparkplug topic payloads before ACL matching', () => {
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.digital-twin',
+      backend: 'mqtt-sparkplug',
+      operation: 'subscribe',
+      topic: 'nlx.telemetry.asset.v1',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, BASE_RULES);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('Invalid Sparkplug topic');
+  });
+
+  it('denies when only malformed ACL rules are provided', () => {
+    const malformedRules = [
+      {
+        principal: 'invalid-principal',
+        backend: 'kafka-redpanda',
+        operation: 'publish',
+        topicPattern: 'nlx.recipes.execution.*',
+      },
+    ] as unknown as readonly BrokerAclRule[];
+
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.recipe-executor',
+      backend: 'kafka-redpanda',
+      operation: 'publish',
+      topic: 'nlx.recipes.execution.v1',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, malformedRules);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('ACL rule schema violation');
+  });
+
+  it('appends rule issues when authorization fails with malformed extra rules', () => {
+    const malformedRules = [
+      ...BASE_RULES,
+      {
+        principal: 'svc.recipe-executor',
+        backend: 'kafka-redpanda',
+        operation: 'publish',
+        topicPattern: 'spBv1.0/line-a/DDATA/#',
+      },
+    ] as unknown as readonly BrokerAclRule[];
+
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.recipe-executor',
+      backend: 'kafka-redpanda',
+      operation: 'publish',
+      topic: 'nlx.api.federation.v1',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, malformedRules);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('No ACL rule matched');
+    expect(decision.reason).toContain('ACL rule schema violation');
+  });
+
+  it('denies Sparkplug patterns that place # before the final segment', () => {
+    const rulesWithInvalidMultiLevelWildcard = [
+      {
+        principal: 'svc.digital-twin',
+        backend: 'mqtt-sparkplug',
+        operation: 'subscribe',
+        topicPattern: 'spBv1.0/line-a/#/conveyor-01',
+      },
+    ] as const;
+
+    const request: BrokerAclAuthorizationRequest = {
+      principal: 'svc.digital-twin',
+      backend: 'mqtt-sparkplug',
+      operation: 'subscribe',
+      topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+    };
+
+    const decision = authorizeBrokerTopicAccess(request, rulesWithInvalidMultiLevelWildcard);
+
+    expect(decision.authorized).toBe(false);
+    expect(decision.reason).toContain('No ACL rule matched');
+  });
+
+  it('returns invalid when ACL coverage is missing for a registration', () => {
+    const registrations: readonly BrokerAclAuthorizationRequest[] = [
+      {
+        principal: 'svc.recipe-executor',
+        backend: 'kafka-redpanda',
+        operation: 'publish',
+        topic: 'nlx.recipes.execution.v1',
+      },
+      {
+        principal: 'svc.mission-control',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topic: 'nlx.api.federation.v1',
+      },
+    ];
+
+    const result = validateBrokerAclCoverage(registrations, BASE_RULES);
+
+    expect(result.valid).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]?.principal).toBe('svc.mission-control');
+  });
+
+  it('captures invalid registration schema errors in coverage validation', () => {
+    const malformedRegistrations = [
+      {
+        principal: 'mission-control',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topic: 'nlx.api.federation.v1',
+      },
+    ] as unknown as readonly BrokerAclAuthorizationRequest[];
+
+    const result = validateBrokerAclCoverage(malformedRegistrations, BASE_RULES);
+
+    expect(result.valid).toBe(false);
+    expect(result.violations[0]?.reason).toContain('Registration schema violation');
+  });
+
+  it('captures invalid topic/backend combinations in coverage validation', () => {
+    const registrations: readonly BrokerAclAuthorizationRequest[] = [
+      {
+        principal: 'svc.digital-twin',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+      },
+    ];
+
+    const result = validateBrokerAclCoverage(registrations, BASE_RULES);
+
+    expect(result.valid).toBe(false);
+    expect(result.violations[0]?.reason).toContain('Invalid Kafka/Redpanda topic');
+  });
+
+  it('collects malformed ACL rule diagnostics while still evaluating valid rules', () => {
+    const malformedRules = [
+      ...BASE_RULES,
+      {
+        principal: 'mission-control',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topicPattern: 'nlx.api.federation.*',
+      },
+    ] as unknown as readonly BrokerAclRule[];
+
+    const registrations: readonly BrokerAclAuthorizationRequest[] = [
+      {
+        principal: 'svc.recipe-executor',
+        backend: 'kafka-redpanda',
+        operation: 'publish',
+        topic: 'nlx.recipes.execution.v1',
+      },
+    ];
+
+    const result = validateBrokerAclCoverage(registrations, malformedRules);
+
+    expect(result.valid).toBe(true);
+    expect(result.ruleIssues.length).toBeGreaterThan(0);
+    expect(result.ruleIssues[0]).toContain('ACL rule schema violation');
+  });
+
+  it('throws with violation details when bootstrap ACL coverage fails', () => {
+    const registrations: readonly BrokerAclAuthorizationRequest[] = [
+      {
+        principal: 'svc.mission-control',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topic: 'nlx.api.federation.v1',
+      },
+    ];
+
+    expect(() => assertBrokerAclCoverage(registrations, BASE_RULES)).toThrow(
+      'Broker ACL coverage failed bootstrap validation'
+    );
+  });
+
+  it('includes ACL rule diagnostics when assertion fails with malformed rules', () => {
+    const malformedRules = [
+      ...BASE_RULES,
+      {
+        principal: 'svc.mission-control',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topicPattern: 'spBv1.0/line-a/DDATA/#',
+      },
+    ] as unknown as readonly BrokerAclRule[];
+
+    const registrations: readonly BrokerAclAuthorizationRequest[] = [
+      {
+        principal: 'svc.mission-control',
+        backend: 'kafka-redpanda',
+        operation: 'subscribe',
+        topic: 'nlx.api.federation.v1',
+      },
+    ];
+
+    expect(() => assertBrokerAclCoverage(registrations, malformedRules)).toThrow('Rule issues:');
+  });
+
+  it('does not throw when all registrations are covered by ACL rules', () => {
+    const registrations: readonly BrokerAclAuthorizationRequest[] = [
+      {
+        principal: 'svc.recipe-executor',
+        backend: 'kafka-redpanda',
+        operation: 'publish',
+        topic: 'nlx.recipes.execution.v1',
+      },
+      {
+        principal: 'svc.digital-twin',
+        backend: 'mqtt-sparkplug',
+        operation: 'subscribe',
+        topic: 'spBv1.0/line-a/DDATA/plc-01/conveyor-01',
+      },
+    ];
+
+    expect(() => assertBrokerAclCoverage(registrations, BASE_RULES)).not.toThrow();
+  });
+});

--- a/packages/schemas/src/broker/acl.ts
+++ b/packages/schemas/src/broker/acl.ts
@@ -1,0 +1,270 @@
+import { z } from 'zod';
+
+import {
+  BrokerAclRuleSchema,
+  BrokerBackendSchema,
+  KafkaTopicContractSchema,
+  SparkplugTopicContractSchema,
+  type BrokerAclRule,
+  type BrokerBackend,
+} from './index';
+
+const BrokerAclAuthorizationRequestSchema = z.object({
+  principal: z
+    .string()
+    .regex(/^svc\.[a-z0-9-]+$/, 'Principal must use svc.<service-name> format'),
+  backend: BrokerBackendSchema,
+  operation: z.enum(['publish', 'subscribe']),
+  topic: z.string().min(1),
+});
+
+export type BrokerAclAuthorizationRequest = z.infer<typeof BrokerAclAuthorizationRequestSchema>;
+
+export interface BrokerAclAuthorizationDecision {
+  authorized: boolean;
+  reason?: string;
+  matchedRule?: BrokerAclRule;
+}
+
+export interface BrokerAclCoverageViolation extends BrokerAclAuthorizationRequest {
+  reason: string;
+}
+
+export interface BrokerAclCoverageResult {
+  valid: boolean;
+  violations: BrokerAclCoverageViolation[];
+  ruleIssues: string[];
+}
+
+function formatSchemaIssues(prefix: string, issues: { path: (string | number)[]; message: string }[]): string[] {
+  return issues.map((issue) => {
+    const path = issue.path.length > 0 ? ` at ${issue.path.join('.')}` : '';
+    return `${prefix}${path}: ${issue.message}`;
+  });
+}
+
+function validateTopicForBackend(backend: BrokerBackend, topic: string): string[] {
+  if (backend === 'mqtt-sparkplug') {
+    const sparkplugParse = SparkplugTopicContractSchema.safeParse(topic);
+    if (!sparkplugParse.success) {
+      return formatSchemaIssues('Invalid Sparkplug topic', sparkplugParse.error.issues);
+    }
+
+    return [];
+  }
+
+  const kafkaParse = KafkaTopicContractSchema.safeParse(topic);
+  if (!kafkaParse.success) {
+    return formatSchemaIssues('Invalid Kafka/Redpanda topic', kafkaParse.error.issues);
+  }
+
+  return [];
+}
+
+function parseAclRules(rules: readonly BrokerAclRule[]): {
+  validRules: BrokerAclRule[];
+  ruleIssues: string[];
+} {
+  const validRules: BrokerAclRule[] = [];
+  const ruleIssues: string[] = [];
+
+  for (const rule of rules) {
+    const parse = BrokerAclRuleSchema.safeParse(rule);
+    if (parse.success) {
+      validRules.push(parse.data);
+      continue;
+    }
+
+    ruleIssues.push(...formatSchemaIssues('ACL rule schema violation', parse.error.issues));
+  }
+
+  return {
+    validRules,
+    ruleIssues,
+  };
+}
+
+function matchesKafkaTopicPattern(pattern: string, topic: string): boolean {
+  const patternSegments = pattern.split('.');
+  const topicSegments = topic.split('.');
+
+  if (patternSegments.length !== topicSegments.length) {
+    return false;
+  }
+
+  return patternSegments.every((segment, index) => {
+    if (segment === '*') {
+      return true;
+    }
+
+    return segment === topicSegments[index];
+  });
+}
+
+function matchesSparkplugTopicPattern(pattern: string, topic: string): boolean {
+  const patternSegments = pattern.split('/');
+  const topicSegments = topic.split('/');
+  let topicIndex = 0;
+
+  for (let patternIndex = 0; patternIndex < patternSegments.length; patternIndex += 1) {
+    const patternSegment = patternSegments[patternIndex];
+
+    if (patternSegment === '#') {
+      return patternIndex === patternSegments.length - 1;
+    }
+
+    const topicSegment = topicSegments[topicIndex];
+    if (!topicSegment) {
+      return false;
+    }
+
+    if (patternSegment !== '+' && patternSegment !== topicSegment) {
+      return false;
+    }
+
+    topicIndex += 1;
+  }
+
+  return topicIndex === topicSegments.length;
+}
+
+function matchesRuleTopicPattern(rule: BrokerAclRule, topic: string): boolean {
+  if (rule.backend === 'mqtt-sparkplug') {
+    return matchesSparkplugTopicPattern(rule.topicPattern, topic);
+  }
+
+  return matchesKafkaTopicPattern(rule.topicPattern, topic);
+}
+
+function evaluateAuthorizationWithValidatedRules(
+  request: BrokerAclAuthorizationRequest,
+  rules: readonly BrokerAclRule[]
+): BrokerAclAuthorizationDecision {
+  const matchedRule = rules.find((rule) => {
+    return (
+      rule.principal === request.principal &&
+      rule.backend === request.backend &&
+      rule.operation === request.operation &&
+      matchesRuleTopicPattern(rule, request.topic)
+    );
+  });
+
+  if (!matchedRule) {
+    return {
+      authorized: false,
+      reason: `No ACL rule matched ${request.principal} ${request.operation} on ${request.backend} topic ${request.topic}.`,
+    };
+  }
+
+  return {
+    authorized: true,
+    matchedRule,
+  };
+}
+
+export function authorizeBrokerTopicAccess(
+  request: BrokerAclAuthorizationRequest,
+  rules: readonly BrokerAclRule[]
+): BrokerAclAuthorizationDecision {
+  const requestParse = BrokerAclAuthorizationRequestSchema.safeParse(request);
+  if (!requestParse.success) {
+    const issues = formatSchemaIssues('Authorization request schema violation', requestParse.error.issues);
+    return {
+      authorized: false,
+      reason: issues.join(' | '),
+    };
+  }
+
+  const normalizedRequest = requestParse.data;
+  const topicIssues = validateTopicForBackend(normalizedRequest.backend, normalizedRequest.topic);
+  if (topicIssues.length > 0) {
+    return {
+      authorized: false,
+      reason: topicIssues.join(' | '),
+    };
+  }
+
+  const { validRules, ruleIssues } = parseAclRules(rules);
+  if (validRules.length === 0) {
+    return {
+      authorized: false,
+      reason: ruleIssues.length > 0 ? ruleIssues.join(' | ') : 'No ACL rules provided.',
+    };
+  }
+
+  const decision = evaluateAuthorizationWithValidatedRules(normalizedRequest, validRules);
+  if (decision.authorized) {
+    return decision;
+  }
+
+  return {
+    ...decision,
+    reason: ruleIssues.length > 0 ? `${decision.reason} | ${ruleIssues.join(' | ')}` : decision.reason,
+  };
+}
+
+export function validateBrokerAclCoverage(
+  registrations: readonly BrokerAclAuthorizationRequest[],
+  rules: readonly BrokerAclRule[]
+): BrokerAclCoverageResult {
+  const violations: BrokerAclCoverageViolation[] = [];
+  const { validRules, ruleIssues } = parseAclRules(rules);
+
+  for (const registration of registrations) {
+    const requestParse = BrokerAclAuthorizationRequestSchema.safeParse(registration);
+    if (!requestParse.success) {
+      violations.push({
+        ...registration,
+        reason: formatSchemaIssues('Registration schema violation', requestParse.error.issues).join(' | '),
+      });
+      continue;
+    }
+
+    const normalizedRequest = requestParse.data;
+    const topicIssues = validateTopicForBackend(normalizedRequest.backend, normalizedRequest.topic);
+    if (topicIssues.length > 0) {
+      violations.push({
+        ...normalizedRequest,
+        reason: topicIssues.join(' | '),
+      });
+      continue;
+    }
+
+    const decision = evaluateAuthorizationWithValidatedRules(normalizedRequest, validRules);
+    if (!decision.authorized) {
+      violations.push({
+        ...normalizedRequest,
+        reason: decision.reason ?? 'Missing ACL rule.',
+      });
+    }
+  }
+
+  return {
+    valid: violations.length === 0,
+    violations,
+    ruleIssues,
+  };
+}
+
+export function assertBrokerAclCoverage(
+  registrations: readonly BrokerAclAuthorizationRequest[],
+  rules: readonly BrokerAclRule[]
+): void {
+  const result = validateBrokerAclCoverage(registrations, rules);
+
+  if (result.valid) {
+    return;
+  }
+
+  const violationSummary = result.violations
+    .map((violation) => {
+      return `${violation.principal}:${violation.backend}:${violation.operation}:${violation.topic} -> ${violation.reason}`;
+    })
+    .join(' | ');
+
+  const ruleIssueSummary = result.ruleIssues.length > 0 ? ` Rule issues: ${result.ruleIssues.join(' | ')}` : '';
+
+  throw new Error(
+    `Broker ACL coverage failed bootstrap validation with ${result.violations.length} violation(s): ${violationSummary}.${ruleIssueSummary}`
+  );
+}

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -13,6 +13,7 @@ export * from './feature-flags/index.js';
 export * from './sparkplug/index.js';
 export * from './broker/index.js';
 export * from './broker/governance.js';
+export * from './broker/acl.js';
 export * from './intents/index.js';
 export * from './recipes/index.js';
 export * from './assets/index.js';


### PR DESCRIPTION
## Summary
- adds runtime ACL authorization guard in packages/schemas/src/broker/acl.ts
- enforces principal/backend/operation/topic matching for Kafka and Sparkplug patterns
- adds bootstrap coverage validation/assertion helpers for required topic registrations
- exports ACL runtime helpers via packages/schemas/src/index.ts
- updates Phase 1 docs/status for topic ACL runtime enforcement

## Why
Phase 1 still had a documented open gap for topic ACL security. This closes the contract-to-runtime enforcement gap without introducing broker connectivity changes.

## Validation
- 
pm run test:ci --workspace @neurologix/schemas
- 
pm run test:contracts:servers
- 
pm run lint
- 
pm run type-check

## Risk
- low; additive schema package APIs plus tests/doc updates
- no service runtime wiring changes

Closes #115