### PR TITLE
test(#119): add capability-registry contract baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ docker compose logs -f capability-registry
 
 - [x] Schema definitions (Zod + JSON Schema) — federation, broker, feature-flags, telemetry, audit schemas in `packages/schemas`
 - [x] Broker topic governance — runtime enforcement via `BrokerTopicValidator` and `TopicGovernanceRegistry` (#103)
-- [x] Contract testing framework — server contract baselines for site-registry (#109) and mission-control (#113); `npm run test:contracts:servers` CI gate active
+- [x] Contract testing framework — server contract baselines for site-registry (#109), mission-control (#113), and capability-registry (#119); `npm run test:contracts:servers` CI gate active
 - [x] Message broker setup (MQTT + Kafka) — dev runtime baseline wired in `infrastructure/docker/docker-compose.dev.yml` with committed Mosquitto config and CI validation (`npm run validate:broker-runtime`) (#117)
 - [x] Topic ACLs & security — runtime ACL authorization + bootstrap coverage guard in `packages/schemas/src/broker/acl.ts` (#115)
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "turbo run test",
     "test:contract": "npm run test:contracts --workspace @neurologix/site-registry",
     "test:ci": "turbo run test:ci --force",
-    "test:contracts:servers": "npm run test:contracts --workspace @neurologix/site-registry && npm run test:contracts --workspace @neurologix/mission-control",
+    "test:contracts:servers": "npm run test:contracts --workspace @neurologix/site-registry && npm run test:contracts --workspace @neurologix/capability-registry && npm run test:contracts --workspace @neurologix/mission-control",
     "test:e2e": "turbo run test:e2e",
     "type-check": "turbo run type-check",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/services/capability-registry/package.json
+++ b/services/capability-registry/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ci": "vitest run --coverage",
+    "test:contracts": "vitest run src/contracts/capability-registry.contract.test.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/services/capability-registry/src/contracts/capability-registry.contract.test.ts
+++ b/services/capability-registry/src/contracts/capability-registry.contract.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CapabilityHealthSchema,
+  CapabilityInstallRequestSchema,
+  CapabilityRegistryResponseSchema,
+  CapabilitySchema,
+  CapabilityUpdateRequestSchema,
+  RegistryStatsSchema,
+} from '@/types/index';
+import { CapabilityRegistryService } from '@/services/capability-registry.service';
+
+describe('Capability Registry Service Contract Baseline', () => {
+  let service: CapabilityRegistryService;
+
+  beforeEach(() => {
+    service = new CapabilityRegistryService();
+  });
+
+  it('enforces install request and installed capability response contracts', async () => {
+    const request = CapabilityInstallRequestSchema.parse({
+      name: 'contract-capability-a',
+      version: '1.0.0',
+      source: 'https://registry.neurologix.com/packages/contract-capability-a-1.0.0.tar.gz',
+      configuration: {
+        endpoint: 'opc.tcp://plc-a',
+        timeoutMs: 1000,
+      },
+      autoEnable: false,
+      forceUpdate: false,
+    });
+
+    const installed = await service.installCapability(request);
+    const parsed = CapabilitySchema.parse(installed);
+
+    expect(parsed.name).toBe(request.name);
+    expect(parsed.version).toBe(request.version);
+    expect(parsed.status).toBe('installed');
+  });
+
+  it('enforces list response contract shape with pagination metadata', async () => {
+    await service.installCapability(
+      CapabilityInstallRequestSchema.parse({
+        name: 'contract-capability-b',
+        version: '1.1.0',
+        source: 'https://registry.neurologix.com/packages/contract-capability-b-1.1.0.tar.gz',
+        autoEnable: true,
+        forceUpdate: false,
+      })
+    );
+
+    const response = await service.listCapabilities({ limit: 10, offset: 0 });
+    const parsed = CapabilityRegistryResponseSchema.parse(response);
+
+    expect(parsed.limit).toBe(10);
+    expect(parsed.offset).toBe(0);
+    expect(parsed.total).toBeGreaterThanOrEqual(1);
+    expect(parsed.capabilities.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('enforces update request and response contract shape for restart-required updates', async () => {
+    const installed = await service.installCapability(
+      CapabilityInstallRequestSchema.parse({
+        name: 'contract-capability-c',
+        version: '2.0.0',
+        source: 'https://registry.neurologix.com/packages/contract-capability-c-2.0.0.tar.gz',
+        autoEnable: true,
+        forceUpdate: false,
+      })
+    );
+
+    const updateRequest = CapabilityUpdateRequestSchema.parse({
+      version: '2.1.0',
+      configuration: {
+        maxRetries: 3,
+      },
+      restartRequired: true,
+    });
+
+    const updated = await service.updateCapability(installed.id, updateRequest);
+    const parsed = CapabilitySchema.parse(updated);
+
+    expect(parsed.id).toBe(installed.id);
+    expect(parsed.version).toBe(updateRequest.version);
+    expect(parsed.status).toBe('updating');
+  });
+
+  it('enforces capability health response contract shape', async () => {
+    const installed = await service.installCapability(
+      CapabilityInstallRequestSchema.parse({
+        name: 'contract-capability-d',
+        version: '3.0.0',
+        source: 'https://registry.neurologix.com/packages/contract-capability-d-3.0.0.tar.gz',
+        autoEnable: true,
+        forceUpdate: false,
+      })
+    );
+
+    const health = await service.checkCapabilityHealth(installed.id);
+    const parsed = CapabilityHealthSchema.parse(health);
+
+    expect(parsed.capabilityId).toBe(installed.id);
+    expect(['enabled', 'failed', 'installed', 'disabled', 'updating', 'uninstalling']).toContain(
+      parsed.status
+    );
+  });
+
+  it('enforces registry stats response contract shape', async () => {
+    await service.installCapability(
+      CapabilityInstallRequestSchema.parse({
+        name: 'contract-capability-e',
+        version: '4.0.0',
+        source: 'https://registry.neurologix.com/packages/contract-capability-e-4.0.0.tar.gz',
+        autoEnable: false,
+        forceUpdate: false,
+      })
+    );
+
+    const stats = await service.getRegistryStats();
+    const parsed = RegistryStatsSchema.parse(stats);
+
+    expect(parsed.total).toBeGreaterThanOrEqual(1);
+    expect(parsed.byType.adapter).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated contract baseline tests for capability lifecycle/service responses in @neurologix/capability-registry
- add 	est:contracts script to services/capability-registry/package.json
- include capability-registry in root 	est:contracts:servers CI gate
- update Phase 1 README contract-testing status

## Validation
- 
pm run test:contracts --workspace @neurologix/capability-registry
- 
pm run test:contracts:servers
- 
pm run lint
- 
pm run type-check

Closes #119