### PR TITLE
test(#125): add digital-twin server contract baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ docker compose logs -f capability-registry
 
 - [x] Schema definitions (Zod + JSON Schema) — federation, broker, feature-flags, telemetry, audit schemas in `packages/schemas`
 - [x] Broker topic governance — runtime enforcement via `BrokerTopicValidator` and `TopicGovernanceRegistry` (#103)
-- [x] Contract testing framework — server contract baselines for site-registry (#109), mission-control (#113), capability-registry (#119), policy-engine (#121), and recipe-executor (#123); `npm run test:contracts:servers` CI gate active
+- [x] Contract testing framework — server contract baselines for site-registry (#109), mission-control (#113), capability-registry (#119), policy-engine (#121), recipe-executor (#123), and digital-twin (#125); `npm run test:contracts:servers` CI gate active
 - [x] Message broker setup (MQTT + Kafka) — dev runtime baseline wired in `infrastructure/docker/docker-compose.dev.yml` with committed Mosquitto config and CI validation (`npm run validate:broker-runtime`) (#117)
 - [x] Topic ACLs & security — runtime ACL authorization + bootstrap coverage guard in `packages/schemas/src/broker/acl.ts` (#115)
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "turbo run test",
     "test:contract": "npm run test:contracts --workspace @neurologix/site-registry",
     "test:ci": "turbo run test:ci --force",
-    "test:contracts:servers": "npm run test:contracts --workspace @neurologix/site-registry && npm run test:contracts --workspace @neurologix/capability-registry && npm run test:contracts --workspace @neurologix/policy-engine && npm run test:contracts --workspace @neurologix/recipe-executor && npm run test:contracts --workspace @neurologix/mission-control",
+    "test:contracts:servers": "npm run test:contracts --workspace @neurologix/site-registry && npm run test:contracts --workspace @neurologix/capability-registry && npm run test:contracts --workspace @neurologix/policy-engine && npm run test:contracts --workspace @neurologix/recipe-executor && npm run test:contracts --workspace @neurologix/digital-twin && npm run test:contracts --workspace @neurologix/mission-control",
     "test:e2e": "turbo run test:e2e",
     "type-check": "turbo run type-check",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/services/digital-twin/package.json
+++ b/services/digital-twin/package.json
@@ -16,6 +16,7 @@
     "dev": "tsc --build --watch",
     "test": "vitest run",
     "test:ci": "vitest run --coverage",
+    "test:contracts": "npm run build --workspace @neurologix/core && npm run build --workspace @neurologix/schemas && vitest run src/contracts/digital-twin.contract.test.ts",
     "test:watch": "vitest",
     "type-check": "tsc --build --force --pretty false",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"

--- a/services/digital-twin/src/contracts/digital-twin.contract.test.ts
+++ b/services/digital-twin/src/contracts/digital-twin.contract.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  SimulationRunSchema,
+  TwinAsset,
+  TwinAssetSchema,
+  TwinQuerySchema,
+  TwinStateSchema,
+  TwinStatisticsSchema,
+  TwinValidationResultSchema,
+} from '../types/index.js';
+import { DigitalTwinService } from '../services/digital-twin.service.js';
+
+const buildTwinInput = (
+  overrides: Partial<Omit<TwinAsset, 'id' | 'createdAt' | 'updatedAt'>> = {}
+): Omit<TwinAsset, 'id' | 'createdAt' | 'updatedAt'> => ({
+  assetId: 'asset-contract-a',
+  name: 'Contract Conveyor Twin',
+  assetType: 'conveyor',
+  status: 'online',
+  zone: 'line-a',
+  metadata: {
+    suite: 'digital-twin-contracts',
+  },
+  ...overrides,
+});
+
+describe('Digital Twin Service Contract Baseline', () => {
+  let service: DigitalTwinService;
+
+  beforeEach(() => {
+    service = new DigitalTwinService();
+  });
+
+  it('enforces create twin response contract shape', async () => {
+    const created = await service.createTwin(buildTwinInput());
+    const parsed = TwinAssetSchema.parse(created);
+
+    expect(parsed.assetId).toBe('asset-contract-a');
+    expect(parsed.assetType).toBe('conveyor');
+    expect(parsed.zone).toBe('line-a');
+  });
+
+  it('enforces twin query response contract shape with pagination metadata', async () => {
+    await service.createTwin(buildTwinInput());
+    await service.createTwin(
+      buildTwinInput({
+        assetId: 'asset-contract-b',
+        name: 'Contract Sensor Twin',
+        assetType: 'sensor',
+        status: 'offline',
+        zone: 'line-b',
+      })
+    );
+
+    const query = TwinQuerySchema.parse({
+      assetType: 'sensor',
+      page: 1,
+      pageSize: 5,
+      sortBy: 'name',
+      sortOrder: 'asc',
+    });
+
+    const response = await service.queryTwins(query);
+    response.twins.forEach(twin => TwinAssetSchema.parse(twin));
+
+    expect(response.page).toBe(query.page);
+    expect(response.pageSize).toBe(query.pageSize);
+    expect(response.total).toBe(1);
+    expect(response.totalPages).toBe(1);
+    expect(response.twins[0]?.assetType).toBe('sensor');
+  });
+
+  it('enforces state ingestion and latest state response contract shape', async () => {
+    const twin = await service.createTwin(buildTwinInput());
+
+    const ingested = await service.ingestState(twin.id, {
+      source: 'telemetry',
+      properties: {
+        speed: 120,
+        load: 0.82,
+      },
+      confidence: 0.99,
+      timestamp: new Date('2026-03-11T10:00:00.000Z'),
+    });
+
+    const latest = await service.getLatestState(twin.id);
+    const parsedIngested = TwinStateSchema.parse(ingested);
+    const parsedLatest = TwinStateSchema.parse(latest);
+
+    expect(parsedIngested.twinId).toBe(twin.id);
+    expect(parsedIngested.version).toBe(1);
+    expect(parsedLatest.properties).toEqual({ speed: 120, load: 0.82 });
+  });
+
+  it('enforces validation response contract shape', async () => {
+    const twin = await service.createTwin(buildTwinInput());
+
+    const validation = await service.validateTwin(twin.id);
+    const parsed = TwinValidationResultSchema.parse(validation);
+
+    expect(parsed.twinId).toBe(twin.id);
+    expect(parsed.isValid).toBe(true);
+    expect(parsed.issues.some(issue => issue.code === 'NO_STATE')).toBe(true);
+  });
+
+  it('enforces simulation response contract shape', async () => {
+    const twin = await service.createTwin(buildTwinInput());
+    await service.ingestState(twin.id, {
+      source: 'telemetry',
+      properties: {
+        speed: 100,
+        enabled: true,
+      },
+      confidence: 1,
+      timestamp: new Date('2026-03-11T10:05:00.000Z'),
+    });
+
+    const simulation = await service.runSimulation(twin.id, {
+      maxSteps: 3,
+      timeScale: 1,
+      stepIntervalMs: 100,
+      includeStochastic: false,
+      seed: 7,
+    });
+    const parsed = SimulationRunSchema.parse(simulation);
+
+    expect(parsed.twinId).toBe(twin.id);
+    expect(parsed.status).toBe('completed');
+    expect(parsed.currentStep).toBe(3);
+    expect(parsed.outputStates).toHaveLength(3);
+  });
+
+  it('enforces statistics response contract shape', async () => {
+    const twin = await service.createTwin(buildTwinInput());
+    await service.ingestState(twin.id, {
+      source: 'manual',
+      properties: {
+        speed: 10,
+      },
+      confidence: 1,
+      timestamp: new Date('2026-03-11T10:10:00.000Z'),
+    });
+    await service.runSimulation(twin.id, {
+      maxSteps: 2,
+      timeScale: 1,
+      stepIntervalMs: 50,
+      includeStochastic: false,
+      seed: 3,
+    });
+
+    const stats = await service.getStatistics();
+    const parsed = TwinStatisticsSchema.parse(stats);
+
+    expect(parsed.totalTwins).toBe(1);
+    expect(parsed.twinsByType.conveyor).toBe(1);
+    expect(parsed.twinsByStatus.online).toBe(1);
+    expect(parsed.twinsWithState).toBe(1);
+    expect(parsed.totalSimulations).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Digital Twin server contract baseline
- wire `@neurologix/digital-twin` into the server contract gate
- update Phase 1 README tracking for Digital Twin contract coverage

## Problem
`@neurologix/digital-twin` was the remaining core runtime service without a dedicated server contract suite in the Phase 1 contract-testing pattern.

## Validation
- npm run test:contracts --workspace @neurologix/digital-twin
- npm run test:contracts:servers
- npm run lint
- npm run type-check

Closes #125