### PR TITLE
docs(#127): reconcile ADR index and phase-0 gap-report completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ docker compose logs -f capability-registry
 - [ ] CI/CD pipelines
 - [ ] Observability stack setup
 - [ ] Security baseline
-- [ ] Architecture documentation ([Phase 0 gap report](./docs/architecture/phase-0-gap-report.md), [Phase 1 definition of ready](./docs/architecture/phase-1-definition-of-ready.md))
+- [x] Architecture documentation ([Phase 0 gap report](./docs/architecture/phase-0-gap-report.md), [Phase 1 definition of ready](./docs/architecture/phase-1-definition-of-ready.md))
 
 ### 🔄 Phase 1 — Data Spine & Contracts
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,12 +16,14 @@ consequences.
 - [ADR-002: TypeScript and Build System](./ADR-002-typescript-build-system.md)
 - [ADR-003: Security-First Architecture](./ADR-003-security-first-architecture.md)
 - [ADR-004: Observability Strategy](./ADR-004-observability-strategy.md)
+- [Phase 0 Gap Report (Foundations Hardening)](./phase-0-gap-report.md)
 
 ### Phase 1 - Data Spine
 
 - [ADR-005: Message Broker Selection](./ADR-005-message-broker-selection.md)
 - [ADR-006: Schema Registry and Contracts](./ADR-006-schema-registry-contracts.md)
 - [Phase 1 Topic Governance (Bounded Slice)](./phase-1-topic-governance.md)
+- [Phase 1 Definition of Ready](./phase-1-definition-of-ready.md)
 
 ### Phase 2 - Core Runtime
 

--- a/docs/architecture/phase-0-gap-report.md
+++ b/docs/architecture/phase-0-gap-report.md
@@ -49,13 +49,13 @@ the repository's current, committed directories.
 | ADR in index | File exists | Gap classification |
 |---|---|---|
 | ADR-001 | Yes | None |
-| ADR-002 | No | Missing artifact |
-| ADR-003 | No | Missing artifact |
-| ADR-004 | No | Missing artifact |
-| ADR-005 | No | Missing artifact |
-| ADR-006 | No | Missing artifact |
-| ADR-007 | No | Missing artifact |
-| ADR-008 | No | Missing artifact |
+| ADR-002 | Yes | Resolved |
+| ADR-003 | Yes | Resolved |
+| ADR-004 | Yes | Resolved |
+| ADR-005 | Yes | Resolved |
+| ADR-006 | Yes | Resolved |
+| ADR-007 | Yes | Resolved |
+| ADR-008 | Yes | Resolved |
 
 ### Bounded Remediation Recommendation
 


### PR DESCRIPTION
## Summary

Docs-only reconciliation slice that closes three documentation drift items identified after ADRs 002–009 were authored:

## Changes

### 1. ADR index now includes two previously unlinked files (`docs/architecture/README.md`)
- Added `phase-0-gap-report.md` under Phase 0 section
- Added `phase-1-definition-of-ready.md` under Phase 1 section

Both files existed on disk and were referenced from the root `README.md`, but were absent from the canonical ADR index.

### 2. Phase-0 gap table updated to reflect current reality (`docs/architecture/phase-0-gap-report.md`)
- All ADR-002 through ADR-008 rows changed from `Missing artifact` → `Resolved`
- All seven files now exist with substantial content; the old table was actively misleading for future readers and agents

### 3. Phase 0 architecture documentation checklist marked done (`README.md`)
- `[ ] Architecture documentation` → `[x] Architecture documentation`
- The phase-0-gap-report condition for marking this done: _"index and authored files are consistent"_ is now satisfied

## Validation

- `npm run lint`: all 14 tasks successful ✅
- `npm run type-check`: all 16 tasks successful ✅
- No runtime code, CI config, or schema changes in this commit

## Closes

Closes #127
