### PR TITLE
feat(#131): implement SITE-005, FF-002, FF-003 federation endpoints in mission-control

### DIFF
--- a/apps/mission-control/src/server.contract.test.ts
+++ b/apps/mission-control/src/server.contract.test.ts
@@ -4,8 +4,9 @@
  * Validates that mission-control's implemented federation HTTP routes conform to
  * the canonical FEDERATION_API_CONTRACTS defined in @neurologix/schemas.
  *
- * Covered contract IDs: SITE-001, SITE-002, SITE-003, SITE-004, FF-001, FED-001
- * Explicitly uncovered (not yet implemented): SITE-005, FF-002, FF-003
+ * Covered contract IDs: SITE-001, SITE-002, SITE-003, SITE-004, SITE-005,
+ *                       FF-001, FF-002, FF-003, FED-001
+ * Explicitly uncovered: (none — all 9 federation contracts are now covered)
  *
  * Pattern: test HTTP routes via Fastify inject(), then cross-check status codes
  * and error codes against contract metadata to detect drift early.
@@ -16,6 +17,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   FEDERATION_API_CONTRACTS,
+  FeatureFlagSchema,
   FederationTopologySchema,
   SiteProfileSchema,
   getContractById,
@@ -33,7 +35,10 @@ const COVERED_PROVIDER_CONTRACT_IDS = [
   'SITE-002',
   'SITE-003',
   'SITE-004',
+  'SITE-005',
   'FF-001',
+  'FF-002',
+  'FF-003',
   'FED-001',
 ] as const;
 
@@ -81,7 +86,8 @@ describe('Mission Control Federation Provider Contract Baseline', () => {
       .sort();
 
     // Snapshot uncovered IDs so any new contract addition requires a conscious coverage decision.
-    expect(uncoveredIds).toEqual(['FF-002', 'FF-003', 'SITE-005']);
+    // All 9 federation contract endpoints are now covered.
+    expect(uncoveredIds).toEqual([]);
   });
 
   it('validates contract metadata for all covered contract IDs', () => {
@@ -245,6 +251,111 @@ describe('Mission Control Federation Provider Contract Baseline', () => {
       const response = await app.inject({ method: 'GET', url: '/api/federation' });
       expectSuccessStatus('FED-001', response.statusCode);
       FederationTopologySchema.parse(response.json());
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PUT /api/sites/:siteId/config success (200) and SITE_NOT_FOUND (404) align with SITE-005', async () => {
+    const { app } = buildMissionControlServer({ startTicker: false, logger: false });
+    try {
+      const createResponse = await app.inject({
+        method: 'POST',
+        url: '/api/sites',
+        payload: {
+          slug: 'contract-provider-site-e',
+          name: 'Contract Provider Site E',
+          region: 'us-west-2',
+          tier: 'T2',
+          config: { timezone: 'America/Los_Angeles', locale: 'en-US' },
+        },
+      });
+      const createdSite = SiteProfileSchema.parse(createResponse.json());
+
+      const newConfig = { timezone: 'Europe/London', locale: 'en-GB', retentionDays: 180 };
+      const updated = await app.inject({
+        method: 'PUT',
+        url: `/api/sites/${createdSite.id}/config`,
+        payload: newConfig,
+      });
+      expectSuccessStatus('SITE-005', updated.statusCode);
+      const updatedSite = SiteProfileSchema.parse(updated.json());
+      expect(updatedSite.config.timezone).toBe('Europe/London');
+      expect(updatedSite.config.locale).toBe('en-GB');
+
+      const missing = await app.inject({
+        method: 'PUT',
+        url: '/api/sites/no-such-site/config',
+        payload: newConfig,
+      });
+      const missingBody = missing.json() as { code: string };
+      expect(missing.statusCode).toBe(404);
+      expect(missingBody.code).toBe('SITE_NOT_FOUND');
+      expectErrorInContract('SITE-005', missing.statusCode, missingBody.code);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PUT /api/feature-flags/:key success (200) aligns with FF-002', async () => {
+    const { app } = buildMissionControlServer({ startTicker: false, logger: false });
+    try {
+      const flagPayload = {
+        key: 'dark-mode',
+        description: 'Enables dark mode for the operator dashboard',
+        defaultValue: false,
+      };
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/feature-flags/dark-mode',
+        payload: flagPayload,
+      });
+      expectSuccessStatus('FF-002', response.statusCode);
+      const flag = FeatureFlagSchema.parse(response.json());
+      expect(flag.key).toBe('dark-mode');
+      expect(flag.defaultValue).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /api/sites/:siteId/feature-flags success (200) and SITE_NOT_FOUND (404) align with FF-003', async () => {
+    const { app } = buildMissionControlServer({ startTicker: false, logger: false });
+    try {
+      const createResponse = await app.inject({
+        method: 'POST',
+        url: '/api/sites',
+        payload: {
+          slug: 'contract-provider-site-f',
+          name: 'Contract Provider Site F',
+          region: 'eu-north-1',
+          tier: 'T3',
+          config: { timezone: 'Europe/Stockholm', locale: 'sv-SE' },
+        },
+      });
+      const createdSite = SiteProfileSchema.parse(createResponse.json());
+
+      const overridesPayload = { 'dark-mode': true, 'beta-dashboard': false };
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/api/sites/${createdSite.id}/feature-flags`,
+        payload: overridesPayload,
+      });
+      expectSuccessStatus('FF-003', response.statusCode);
+      const result = response.json() as { siteId: string; featureFlags: Record<string, boolean> };
+      expect(result.siteId).toBe(createdSite.id);
+      expect(result.featureFlags['dark-mode']).toBe(true);
+      expect(result.featureFlags['beta-dashboard']).toBe(false);
+
+      const missing = await app.inject({
+        method: 'PATCH',
+        url: '/api/sites/no-such-site/feature-flags',
+        payload: overridesPayload,
+      });
+      const missingBody = missing.json() as { code: string };
+      expect(missing.statusCode).toBe(404);
+      expect(missingBody.code).toBe('SITE_NOT_FOUND');
+      expectErrorInContract('FF-003', missing.statusCode, missingBody.code);
     } finally {
       await app.close();
     }

--- a/apps/mission-control/src/server.ts
+++ b/apps/mission-control/src/server.ts
@@ -821,5 +821,80 @@ export function buildMissionControlServer(
     }
   });
 
+  // SITE-005: Replace operational configuration for a site
+  app.put('/api/sites/:siteId/config', async (request, reply) => {
+    try {
+      const { siteId } = request.params as { siteId: string };
+      const updated = await siteRegistry.updateSiteConfig(
+        siteId,
+        request.body as Parameters<SiteRegistryService['updateSiteConfig']>[1],
+      );
+      return updated;
+    } catch (error) {
+      if (error instanceof Error && 'code' in error) {
+        const siteError = error as { code: string; message: string };
+        if (siteError.code === SITE_REGISTRY_ERROR_CODES.SITE_NOT_FOUND) {
+          reply.status(404);
+          return { code: siteError.code, message: siteError.message, traceId: request.id };
+        }
+        if (siteError.code === SITE_REGISTRY_ERROR_CODES.VALIDATION_ERROR) {
+          reply.status(400);
+          return { code: siteError.code, message: siteError.message, traceId: request.id };
+        }
+      }
+      const message = error instanceof Error ? error.message : 'Failed to update site config';
+      reply.status(500);
+      return { code: 'INTERNAL_ERROR', message, traceId: request.id };
+    }
+  });
+
+  // FF-002: Create or update a feature flag definition
+  app.put('/api/feature-flags/:key', async (request, reply) => {
+    try {
+      const flag = await siteRegistry.upsertFeatureFlag(
+        request.body as Parameters<SiteRegistryService['upsertFeatureFlag']>[0],
+      );
+      return flag;
+    } catch (error) {
+      if (error instanceof Error && 'code' in error) {
+        const siteError = error as { code: string; message: string };
+        if (siteError.code === SITE_REGISTRY_ERROR_CODES.VALIDATION_ERROR) {
+          reply.status(400);
+          return { code: siteError.code, message: siteError.message, traceId: request.id };
+        }
+      }
+      const message = error instanceof Error ? error.message : 'Failed to upsert feature flag';
+      reply.status(500);
+      return { code: 'INTERNAL_ERROR', message, traceId: request.id };
+    }
+  });
+
+  // FF-003: Override feature flags at site level
+  app.patch('/api/sites/:siteId/feature-flags', async (request, reply) => {
+    try {
+      const { siteId } = request.params as { siteId: string };
+      const updated = await siteRegistry.setFeatureFlagOverrides(
+        siteId,
+        request.body as Parameters<SiteRegistryService['setFeatureFlagOverrides']>[1],
+      );
+      return { siteId: updated.id, featureFlags: updated.featureFlags ?? {} };
+    } catch (error) {
+      if (error instanceof Error && 'code' in error) {
+        const siteError = error as { code: string; message: string };
+        if (siteError.code === SITE_REGISTRY_ERROR_CODES.SITE_NOT_FOUND) {
+          reply.status(404);
+          return { code: siteError.code, message: siteError.message, traceId: request.id };
+        }
+        if (siteError.code === SITE_REGISTRY_ERROR_CODES.VALIDATION_ERROR) {
+          reply.status(400);
+          return { code: siteError.code, message: siteError.message, traceId: request.id };
+        }
+      }
+      const message = error instanceof Error ? error.message : 'Failed to update feature flag overrides';
+      reply.status(500);
+      return { code: 'INTERNAL_ERROR', message, traceId: request.id };
+    }
+  });
+
   return { app, state };
 }


### PR DESCRIPTION
## Summary

Closes #131

Implements the three previously uncovered federation API contract endpoints in the mission-control server, completing 100% coverage of all 9 \FEDERATION_API_CONTRACTS\.

## Changes

### \pps/mission-control/src/server.ts\
Added three route handlers:
- \PUT /api/sites/:siteId/config\ **(SITE-005)** — delegates to \SiteRegistryService.updateSiteConfig()\; returns updated \SiteProfile\ (200) or SITE_NOT_FOUND (404)
- \PUT /api/feature-flags/:key\ **(FF-002)** — delegates to \SiteRegistryService.upsertFeatureFlag()\; returns \FeatureFlag\ (200)
- \PATCH /api/sites/:siteId/feature-flags\ **(FF-003)** — delegates to \SiteRegistryService.setFeatureFlagOverrides()\; returns \{ siteId, featureFlags }\ (200) or SITE_NOT_FOUND (404)

### \pps/mission-control/src/server.contract.test.ts\
- Updated header: all 9 federation contracts now covered
- Added SITE-005, FF-002, FF-003 to \COVERED_PROVIDER_CONTRACT_IDS\
- Updated uncovered snapshot: \['FF-002','FF-003','SITE-005']\ → \[]\
- Added 3 new test cases (success path + error code validation)

## Validation

- \
pm run lint\ — clean (14/14)
- \
pm run type-check\ — clean (16/16)
- \
pm run test --workspace @neurologix/mission-control\ — **43/43 pass** (3 files)

## Risk

Low. No schema changes, no SiteRegistryService changes. Three thin route handlers following identical pattern to existing routes. No auth enforcement (Phase 7 scope).