### PR TITLE
test: add adapters broker consumer contract CI coverage (issue #133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ docker compose logs -f capability-registry
 
 - [x] Schema definitions (Zod + JSON Schema) — federation, broker, feature-flags, telemetry, audit schemas in `packages/schemas`
 - [x] Broker topic governance — runtime enforcement via `BrokerTopicValidator` and `TopicGovernanceRegistry` (#103)
-- [x] Contract testing framework — server contract baselines for site-registry (#109), mission-control (#113), capability-registry (#119), policy-engine (#121), recipe-executor (#123), and digital-twin (#125); `npm run test:contracts:servers` CI gate active
+- [x] Contract testing framework — server contract baselines for site-registry (#109), mission-control (#113), capability-registry (#119), policy-engine (#121), recipe-executor (#123), and digital-twin (#125), plus consumer contract baselines for mission-control (#129) and adapters broker ingestion (#133); `npm run test:contracts:servers` and `npm run test:contracts:consumers` CI gates active
 - [x] Message broker setup (MQTT + Kafka) — dev runtime baseline wired in `infrastructure/docker/docker-compose.dev.yml` with committed Mosquitto config and CI validation (`npm run validate:broker-runtime`) (#117)
 - [x] Topic ACLs & security — runtime ACL authorization + bootstrap coverage guard in `packages/schemas/src/broker/acl.ts` (#115)
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:contract": "npm run test:contracts --workspace @neurologix/site-registry",
     "test:ci": "turbo run test:ci --force",
     "test:contracts:servers": "npm run test:contracts --workspace @neurologix/site-registry && npm run test:contracts --workspace @neurologix/capability-registry && npm run test:contracts --workspace @neurologix/policy-engine && npm run test:contracts --workspace @neurologix/recipe-executor && npm run test:contracts --workspace @neurologix/digital-twin && npm run test:contracts --workspace @neurologix/mission-control",
-  "test:contracts:consumers": "npm run test:contracts:consumer --workspace @neurologix/mission-control",
+    "test:contracts:consumers": "npm run test:contracts:consumer --workspace @neurologix/mission-control && npm run test:contracts --workspace @neurologix/adapters",
     "test:e2e": "turbo run test:e2e",
     "type-check": "turbo run type-check",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -22,6 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ci": "vitest run --coverage",
+    "test:contracts": "vitest run --reporter=verbose src/contracts/broker-consumer.contract.test.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/adapters/src/contracts/broker-consumer.contract.test.ts
+++ b/packages/adapters/src/contracts/broker-consumer.contract.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BROKER_TOPIC_CONTRACTS,
+  DataMessageSchema,
+  TelemetryPointSchema,
+  WmsWcsDispatchCommandSchema,
+  parseSparkplugTopic,
+} from '@neurologix/schemas';
+import { SparkplugEdgeIngestionAdapter } from '../sparkplug/index.js';
+import { WmsWcsCommandIngestionAdapter } from '../wms-wcs/index.js';
+
+describe('Broker consumer contract boundaries', () => {
+  it('ingests canonical Sparkplug contract topic and schema-valid payload', () => {
+    const contractTopic = BROKER_TOPIC_CONTRACTS.find(
+      contract => contract.backend === 'mqtt-sparkplug'
+    );
+
+    expect(contractTopic).toBeDefined();
+    if (!contractTopic || contractTopic.backend !== 'mqtt-sparkplug') {
+      return;
+    }
+
+    const parsedTopic = parseSparkplugTopic(contractTopic.topic);
+    expect(parsedTopic).not.toBeNull();
+
+    const payload = DataMessageSchema.parse({
+      timestamp: 1700000000000,
+      seq: 9,
+      metrics: [
+        {
+          name: 'throughput.units_per_min',
+          timestamp: 1700000000000,
+          datatype: 'Float',
+          value: 138.5,
+        },
+        {
+          name: 'fault.jam_detected',
+          timestamp: 1700000000000,
+          datatype: 'Boolean',
+          value: false,
+        },
+      ],
+    });
+
+    const adapter = new SparkplugEdgeIngestionAdapter();
+    const result = adapter.ingest(contractTopic.topic, payload);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.groupId).toBe('line-a');
+    expect(result.value.edgeNodeId).toBe('plc-01');
+    expect(result.value.deviceId).toBe('conveyor-01');
+    expect(result.value.points).toHaveLength(2);
+
+    for (const point of result.value.points) {
+      const validation = TelemetryPointSchema.safeParse(point);
+      expect(validation.success).toBe(true);
+    }
+  });
+
+  it('rejects Sparkplug payloads that violate canonical DataMessage schema', () => {
+    const adapter = new SparkplugEdgeIngestionAdapter();
+
+    const result = adapter.ingest('spBv1.0/line-a/DDATA/plc-01/conveyor-01', {
+      timestamp: 1700000000000,
+      metrics: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error.code).toBe('INVALID_PAYLOAD');
+  });
+
+  it('rejects Sparkplug topics outside canonical topic contract shape', () => {
+    const adapter = new SparkplugEdgeIngestionAdapter();
+
+    const result = adapter.ingest('spBv1.0/line-a/INVALID/plc-01', {
+      timestamp: 1700000000000,
+      seq: 1,
+      metrics: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error.code).toBe('INVALID_TOPIC');
+  });
+
+  it('ingests schema-valid WMS/WCS dispatch command with deterministic key', () => {
+    const rawCommand = {
+      sourceSystem: 'wms',
+      commandId: 'cmd-133',
+      correlationId: 'corr-133',
+      commandType: 'allocate_pick',
+      facilityId: 'facility-a',
+      targetId: 'order-133',
+      requestedAt: '2026-03-11T10:00:00.000Z',
+    };
+
+    const validatedCommand = WmsWcsDispatchCommandSchema.parse(rawCommand);
+    const adapter = new WmsWcsCommandIngestionAdapter();
+    const result = adapter.ingest(rawCommand);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.source).toBe('wms-wcs');
+    expect(result.value.idempotencyKey).toBe('wms:corr-133');
+    expect(result.value.command).toEqual(validatedCommand);
+  });
+
+  it('rejects WMS/WCS commands that violate dispatch contract schema', () => {
+    const adapter = new WmsWcsCommandIngestionAdapter();
+
+    const result = adapter.ingest({
+      sourceSystem: 'wms',
+      commandId: 'cmd-133',
+      requestedAt: '2026-03-11T10:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error.code).toBe('INVALID_COMMAND');
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit broker consumer contract tests for @neurologix/adapters Sparkplug and WMS/WCS ingestion boundaries
- add 	est:contracts script to @neurologix/adapters
- extend root 	est:contracts:consumers gate to include adapters contract tests
- update Phase 1 contract-testing status in README

## Problem Solved
Closes the Phase 1 broker consumer contract-testing gap by locking adapter ingestion behavior to canonical @neurologix/schemas contracts and enforcing it in CI consumer contract checks.

## Validation
- 
pm run test:contracts --workspace @neurologix/adapters
- 
pm run test:contracts:consumers
- 
pm run lint
- 
pm run type-check

## Issue
Closes #133