### PR TITLE
ci(#135): add contract tests to release CI gate + release rollback runbook

### DIFF
--- a/.developer/RELEASE.md
+++ b/.developer/RELEASE.md
@@ -1,12 +1,161 @@
 # Release Process
 
-## Baseline Flow
+> **Risk Tier:** T1 (Mission-Critical)
+> **Model Ref:** CICD-001 (`.github/.system-state/ci/ci_cd_model.yaml`)
+> **Canary Stages:** 10% → 25% → 50% → 100%
+> **Rollback SLA:** Safe state in < 30 seconds
 
-1. Merge validated PRs to `main`.
-2. Ensure required CI checks pass.
-3. Run release workflow with explicit production input gate.
-4. Monitor rollout and rollback triggers.
+---
 
-## Evidence
+## Pre-Release Checklist
 
-Record release outcomes in planning artifacts and GitHub workflow history.
+Before triggering the release workflow, confirm all of the following:
+
+- [ ] All required CI checks green on `main` (lint, typecheck, tests, contract-tests, build, secrets-scan, dependency-audit)
+- [ ] Coverage thresholds met (≥ 80% overall, ≥ 90% core modules)
+- [ ] All server and consumer contract tests passing locally (`npm run test:contracts:servers && npm run test:contracts:consumers`)
+- [ ] Version string determined (semantic version, e.g. `v1.2.3`)
+- [ ] Release notes drafted
+- [ ] No open P0/P1 incidents
+- [ ] Staging environment healthy (monitoring dashboards green)
+- [ ] Rollback SLA validated (previous rollback tested or documented in staging)
+- [ ] Operations team notified of upcoming release window
+
+---
+
+## Release Workflow
+
+The release is triggered via `workflow_dispatch` on `main`.
+
+### Trigger
+
+```bash
+gh workflow run release.yml \
+  --field version=v1.2.3 \
+  --field skip_e2e=false \
+  --field skip_benchmarks=false
+```
+
+### Pipeline Stages
+
+| Stage | Job | Purpose | Blocks |
+|-------|-----|---------|--------|
+| 1 | lint, typecheck, test | Re-run PR quality gates on release SHA | build |
+| 1b | contract-tests | Server + consumer contract validation | build |
+| 2 | build | Production build + artifact upload | deploy-staging |
+| 3 | e2e | Playwright critical operator journeys (skippable) | deploy-staging |
+| 4 | security-scan | Snyk vulnerability analysis | deploy-staging |
+| 5 | lighthouse-ci | Performance budget gates (conditional on STAGING_URL) | — |
+| 6 | container-scan | Trivy CVE scan (CRITICAL + HIGH) | deploy-staging |
+| 7 | sbom | CycloneDX SBOM generation | deploy-staging |
+| 8 | deploy-staging | Helm rollout to staging cluster | benchmarks |
+| 9 | benchmarks | Pre-release performance gates | deploy-production |
+| 10 | deploy-production | Canary rollout to production (manual approval) | — |
+
+### Canary Rollout Stages
+
+| Stage | Traffic | Monitoring Window |
+|-------|---------|------------------|
+| 1 | 10% | 24 hours |
+| 2 | 25% | 48 hours |
+| 3 | 50% | 72 hours |
+| 4 | 100% | 168 hours |
+
+---
+
+## Rollback Triggers (Automated)
+
+The following conditions automatically trigger rollback in the production canary stage:
+
+| Trigger | Threshold |
+|---------|-----------|
+| Control loop p99 latency | > 200ms |
+| Service error rate | > 0.5% |
+| Recipe execution failure rate | > 0.1% |
+| Safety interlock bypass attempt | Any |
+| Audit log write failure | Any |
+| Health check failure at any canary stage | Any |
+
+---
+
+## Rollback Procedure
+
+### Automated (Release Workflow)
+
+The production deploy job includes automated rollback on failure:
+
+```bash
+# Triggered automatically if deploy-production job fails
+helm rollback neurologix -n neurologix-prod
+```
+
+The release workflow runs this automatically in its `if: failure()` step.
+
+### Manual Emergency Rollback
+
+If the automated rollback fails or you need to roll back post-deployment:
+
+```bash
+# 1. Identify the last known-good release
+helm history neurologix -n neurologix-prod --max 5
+
+# 2. Roll back to the previous release
+helm rollback neurologix -n neurologix-prod
+
+# 3. Verify health after rollback (wait ~60s for pods to restart)
+kubectl rollout status deployment/neurologix -n neurologix-prod
+curl --retry 5 --retry-delay 5 --fail $PRODUCTION_URL/api/health
+
+# 4. Confirm rollback in Grafana dashboards
+echo "Check: $GRAFANA_URL"
+```
+
+**Expected time to safe state: < 30 seconds** (Kubernetes rolling restart)
+
+### Rollback Validation Checklist
+
+After any rollback:
+
+- [ ] All pods Running and Ready (`kubectl get pods -n neurologix-prod`)
+- [ ] `/api/health` endpoint returning 200
+- [ ] Control loop latency p95 < 50ms (Grafana)
+- [ ] No safety interlock errors in logs
+- [ ] Audit log writes resuming (ELK)
+- [ ] Operations team notified
+- [ ] Incident record created in `.developer/INCIDENTS.md`
+- [ ] Root cause logged in GitHub issue/PR comment
+
+---
+
+## Emergency Release (Skip E2E + Benchmarks)
+
+For P0 security patches or hotfixes only:
+
+```bash
+gh workflow run release.yml \
+  --field version=v1.2.4-hotfix.1 \
+  --field skip_e2e=true \
+  --field skip_benchmarks=true
+```
+
+> **Warning:** Emergency bypasses must be approved by the operations lead and documented in `.developer/INCIDENTS.md`.
+
+---
+
+## Post-Release Checklist
+
+- [ ] Production health stable for ≥ 1 hour post-full-rollout
+- [ ] No P0/P1 incidents within the canary window
+- [ ] SBOM artifact archived (Compliance retention: 90 days)
+- [ ] Release notes published on GitHub Releases
+- [ ] `.developer/INCIDENTS.md` updated (if any rollback or degradation occurred)
+- [ ] Monitoring dashboards updated if new SLI/SLO thresholds changed
+
+---
+
+## Related References
+
+- [CI/CD Model](../.github/.system-state/ci/ci_cd_model.yaml)
+- [Release Workflow](../.github/workflows/release.yml)
+- [Release Rollback Runbook](../docs/runbooks/release-rollback.md)
+- [Incidents Log](./INCIDENTS.md)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
   build:
     name: CI Gate / Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, contract-tests]
     steps:
       - uses: actions/checkout@v6
 
@@ -162,6 +162,35 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ============================================================================
+  # Stage 1b: Contract Tests — server and consumer contract validation
+  # Mirrors the mainline CI contract-tests gate to prevent schema-breaking releases.
+  # ============================================================================
+  contract-tests:
+    name: CI Gate / Contract Tests
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace dependencies
+        run: npx turbo run build --filter=!@neurologix/mission-control
+
+      - name: Run server contract tests
+        run: npm run test:contracts:servers
+
+      - name: Run consumer contract tests
+        run: npm run test:contracts:consumers
 
   # ============================================================================
   # Stage 2: E2E Tests — Playwright critical operator journeys

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -5,18 +5,25 @@
 This directory contains operational runbooks for incident response, service
 recovery, and safe-mode procedures.
 
-## Current Status
+## Runbooks
 
-Foundational scaffold. Existing operational guidance also lives in:
+| Runbook | Scope | Status |
+|---------|-------|--------|
+| [release-rollback.md](./release-rollback.md) | Production + staging Helm rollback, automated and manual rollback procedures | Active |
 
-- `.developer/RUNBOOKS/`
+## Related Guidance
+
+Operational guidance also lives in:
+
+- `.developer/RUNBOOKS/` — service-specific runbooks
+- `.developer/RELEASE.md` — full release checklist and rollback triggers
 - planning validation and closure records under `planning/`
 
 ## Near-Term Contents
 
 - Service incident triage playbooks
-- Rollback and safe-state activation steps
-- Validation checklist references for critical paths
+- Safe-mode activation procedures
+- PLC interlock override checklist (Phase 7 — Security & Compliance)
 
 ## Related Architecture Evidence
 

--- a/docs/runbooks/release-rollback.md
+++ b/docs/runbooks/release-rollback.md
@@ -1,0 +1,218 @@
+# Runbook: Release Rollback
+
+> **Risk Tier:** T1 (Mission-Critical)
+> **Scope:** Production and staging Kubernetes canary rollback
+> **Rollback SLA:** Safe state in < 30 seconds
+> **Model Ref:** CICD-001 (`.github/.system-state/ci/ci_cd_model.yaml`)
+
+---
+
+## Purpose
+
+This runbook documents the procedures for rolling back a NeuroLogix production
+or staging deployment when a release triggers an automated or manual rollback.
+
+It is the operational counterpart to `.developer/RELEASE.md` and the
+[Release Workflow](../../.github/workflows/release.yml).
+
+---
+
+## Rollback Triggers
+
+Rollback must be initiated immediately when any of the following are detected:
+
+| Trigger | Threshold | Source |
+|---------|-----------|--------|
+| Control loop p99 latency | > 200ms | Grafana / Prometheus |
+| Service error rate | > 0.5% | Grafana / Prometheus |
+| Recipe execution failure rate | > 0.1% | Application logs / ELK |
+| Safety interlock bypass attempt | Any | Audit log / ELK |
+| Audit log write failure | Any | ELK / alerts |
+| Kubernetes liveness/readiness probe failure | Any | Kubernetes events |
+| Health check failure at canary stage | Any | Release workflow step |
+
+---
+
+## Decision Tree
+
+```
+Deployment triggered (canary stage 1–4)
+   │
+   ├─ Health check fails → AUTOMATED ROLLBACK (workflow handles it)
+   │
+   └─ Manual monitoring detects threshold breach
+          │
+          ├─ Within canary window → Manual rollback (see Section 3)
+          │
+          └─ Post full rollout (100%) → Emergency rollback (see Section 4)
+```
+
+---
+
+## Section 1: Verify Rollback Triggers
+
+Before rolling back, confirm the trigger is real and not a transient blip.
+
+```bash
+# Check recent error rate in Prometheus
+# (replace with your actual query endpoint)
+curl -s "$PROMETHEUS_URL/api/v1/query?query=rate(http_requests_total{status=~'5..'}[5m])"
+
+# Check control loop latency
+kubectl logs -n neurologix-prod -l app=neurologix --tail=50 | grep "control-loop"
+
+# Check safety interlock events
+# Search ELK for: level:error AND tags:safety-interlock
+```
+
+---
+
+## Section 2: Automated Rollback (Release Workflow)
+
+The release workflow's `deploy-production` job automatically rolls back on failure:
+
+```yaml
+# Excerpt from release.yml deploy-production
+- name: Rollback on failure
+  if: failure()
+  run: |
+    helm rollback neurologix -n neurologix-prod || true
+    echo "Rollback initiated."
+```
+
+**No action required** if the release workflow reports failure and initiates rollback.
+
+Verify the automated rollback succeeded:
+
+```bash
+helm history neurologix -n neurologix-prod --max 5
+kubectl get pods -n neurologix-prod
+```
+
+---
+
+## Section 3: Manual Rollback During Canary
+
+Use this procedure when canary is still active (< 100% traffic) and automated rollback did not trigger.
+
+### Step 1 — Confirm current release state
+
+```bash
+helm status neurologix -n neurologix-prod
+helm history neurologix -n neurologix-prod --max 5
+```
+
+### Step 2 — Initiate rollback
+
+```bash
+# Roll back to the previous known-good release
+helm rollback neurologix -n neurologix-prod
+```
+
+### Step 3 — Monitor rollback progress
+
+```bash
+# Watch pods restart
+kubectl rollout status deployment/neurologix -n neurologix-prod --timeout=60s
+
+# Confirm all pods are Running
+kubectl get pods -n neurologix-prod
+```
+
+### Step 4 — Validate health
+
+```bash
+# Health endpoint should return HTTP 200
+curl --retry 5 --retry-delay 5 --fail $PRODUCTION_URL/api/health
+echo "Health check exit code: $?"
+```
+
+### Step 5 — Confirm metrics
+
+- Open Grafana: `$GRAFANA_URL`
+- Verify control loop p95 < 50ms
+- Verify error rate < 0.1%
+- Verify no safety interlock events in last 5 minutes
+
+---
+
+## Section 4: Emergency Rollback (Post Full Rollout)
+
+Use this procedure if a regression is discovered after 100% traffic rollout.
+
+### Step 1 — Immediately roll back
+
+```bash
+helm rollback neurologix -n neurologix-prod
+```
+
+### Step 2 — Verify rollback
+
+```bash
+kubectl rollout status deployment/neurologix -n neurologix-prod --timeout=60s
+curl --retry 5 --retry-delay 5 --fail $PRODUCTION_URL/api/health
+```
+
+### Step 3 — Assess data integrity
+
+```bash
+# Check for any in-flight recipe executions that may have been interrupted
+# Search ELK for: tags:recipe-execution AND status:running
+
+# Check audit log continuity
+# Search ELK for gaps in audit entries after rollback timestamp
+```
+
+### Step 4 — Notify stakeholders
+
+- Notify operations lead and tech lead immediately.
+- Create an incident record in `.developer/INCIDENTS.md`.
+- Update GitHub PR/issue with rollback evidence.
+
+---
+
+## Section 5: Staging Rollback
+
+Use for staging rollback during pre-release validation:
+
+```bash
+helm rollback neurologix-staging -n neurologix-staging
+kubectl get pods -n neurologix-staging
+curl --retry 3 --fail $STAGING_URL/api/health
+```
+
+---
+
+## Post-Rollback Checklist
+
+- [ ] All pods `Running` and `Ready`
+- [ ] `/api/health` returning 200
+- [ ] Control loop latency p95 < 50ms (Grafana)
+- [ ] Error rate < 0.1% (Grafana)
+- [ ] No safety interlock events in last 5 minutes (ELK)
+- [ ] Audit log writes resuming (ELK)
+- [ ] Operations team notified (Slack / PagerDuty)
+- [ ] Incident record created in `.developer/INCIDENTS.md`
+- [ ] Root cause investigation initiated (GitHub issue opened)
+- [ ] Rollback entry added to `helm history` confirmed
+
+---
+
+## Prevention
+
+To reduce rollback frequency:
+
+1. **Always run the full release workflow** — never skip stages on non-hotfix releases.
+2. **Stage canary at 10% for the full 24h window** before advancing.
+3. **Monitor Grafana dashboards continuously** during canary progression.
+4. **Validate contract tests locally** before triggering a release (`npm run test:contracts:servers && npm run test:contracts:consumers`).
+5. **Maintain staging parity** — never deploy to production from an environment that diverges from staging.
+
+---
+
+## Related References
+
+- [Release Process](./.developer/RELEASE.md)
+- [Release Workflow](../../.github/workflows/release.yml)
+- [CI/CD Model](../../.github/.system-state/ci/ci_cd_model.yaml)
+- [Incidents Log](../../.developer/INCIDENTS.md)


### PR DESCRIPTION
## Summary

Closes #135.

Adds contract tests to the release CI gate and creates the T1 release rollback runbook, aligning the release quality gate with the mainline CI quality gate.

## Problem Solved

The release workflow (\elease.yml\) ran lint, typecheck, test, and build but **did not run contract tests**. Contract tests are not in the turbo pipeline so \	urbo run test\ does not exercise them. This meant a schema-breaking change (broken server API, broken federation topology, broken broker message format) could reach staging or production even though the same change would block a PR merge via the mainline CI \contract-tests\ gate.

Additionally, \.developer/RELEASE.md\ was a 4-line stub with no actionable release procedure or rollback evidence.

## Changes

### \.github/workflows/release.yml\
- Added \contract-tests\ job (Stage 1b) running \
pm run test:contracts:servers\ and \
pm run test:contracts:consumers\
- \uild\ job now depends on \contract-tests\ in addition to lint/typecheck/test
- Mirrors the mainline CI gate for release safety

### \.developer/RELEASE.md\
- Expanded from 4-line stub to full release document
- Pre-release checklist, pipeline stage table, canary rollout stages (10%→25%→50%→100%)
- Rollback triggers reference, rollback procedure (automated + manual), emergency release procedure
- Post-release checklist, related references

### \docs/runbooks/release-rollback.md\ (new)
- T1 operations rollback runbook covering automated, manual canary, and emergency post-rollout rollback scenarios
- Decision tree, step-by-step Helm rollback commands, post-rollback validation checklist
- Prevention guidelines

### \docs/runbooks/README.md\
- Replaced scaffold stub with runbook table linking to new release-rollback.md
- Updated guidance links to \.developer/RELEASE.md\

## Validation

- [x] \
pm run lint\ — 14 tasks successful
- [x] \
pm run type-check\ — 16 tasks successful
- [x] Release workflow YAML structure valid
- [x] No changes to application code or mainline CI
- [x] Scope: 4 files, +416/-13 lines

## Risk

None — additive YAML job + documentation only. No behaviour change to mainline CI, no application code changes.