### PR TITLE
ci: add blocking lighthouse gate for mission-control

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -18,6 +18,7 @@
 - [x] CI contract-tests gate (mainline + release workflows)
 - [x] Vitest coverage thresholds enforced repo-wide
 - [x] ADR index and phase-0 gap-report reconciled
+- [x] Lighthouse CI gate for mission-control in mainline CI
 
 ## Active / Near Term
 
@@ -27,7 +28,6 @@
 - Safe-mode activation procedure runbook (Phase 7)
 - PLC interlock override checklist (Phase 7 — Security & Compliance)
 - Expand observability to include Grafana dashboard baselines
-- Continue CI/CD hardening — add Lighthouse CI gate for mission-control
 
 ## Quality Targets
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,73 @@ jobs:
         run: npm run test:contracts:consumers
 
   # ─────────────────────────
+  # Lighthouse CI (Mission Control UX SLO gate)
+  # ─────────────────────────
+  lighthouse-ci:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    needs: [model-state]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace artifacts
+        run: npm run build
+
+      - name: Start mission-control server
+        run: |
+          node -e "import('./apps/mission-control/dist/index.js')" > mission-control.log 2>&1 &
+          echo $! > mission-control.pid
+
+          for i in {1..60}; do
+            if curl -fsS http://localhost:3100/health > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Mission Control did not become healthy in time."
+          cat mission-control.log || true
+          exit 1
+        env:
+          PORT: '3100'
+          HOST: '127.0.0.1'
+          NODE_ENV: test
+
+      - name: Run Lighthouse CI gate
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            http://localhost:3100/
+          budgetPath: ./.lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: false
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop mission-control server
+        if: always()
+        run: |
+          if [ -f mission-control.pid ]; then
+            kill "$(cat mission-control.pid)" || true
+          fi
+
+  # ─────────────────────────
   # Build
   # ─────────────────────────
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [model-state, lint, typecheck, test, contract-tests]
+    needs: [model-state, lint, typecheck, test, contract-tests, lighthouse-ci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,6 @@ jobs:
         with:
           urls: |
             ${{ vars.STAGING_URL }}
-            ${{ vars.STAGING_URL }}/dashboard
           budgetPath: ./.lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: false

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -24,6 +24,7 @@
         "categories:seo": ["warn", { "minScore": 0.8 }],
         "first-contentful-paint": ["warn", { "maxNumericValue": 1500 }],
         "largest-contentful-paint": ["error", { "maxNumericValue": 1200 }],
+        "max-potential-fid": ["error", { "maxNumericValue": 10 }],
         "total-blocking-time": ["warn", { "maxNumericValue": 200 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.05 }],
         "interactive": ["warn", { "maxNumericValue": 2500 }],


### PR DESCRIPTION
## Summary
Adds a blocking Lighthouse CI gate for Mission Control in mainline CI to enforce UX SLO budgets.

## Changes
- Adds `lighthouse-ci` job to `.github/workflows/ci.yml`:
  - installs deps, builds workspace artifacts, starts mission-control server, waits for `/health`, runs Lighthouse, then stops server
  - wired as a required predecessor for `build`
- Updates `.lighthouserc.json` with explicit legacy FID enforcement:
  - `max-potential-fid <= 10`
- Aligns release Lighthouse URL to valid route in `.github/workflows/release.yml` (removes stale `/dashboard` path)
- Updates `.developer/TODO.md` to mark Lighthouse gate complete

## Validation
- `npm run lint` ✅
- `npm run type-check` ✅

## Risk / Rollback
- Risk: CI runtime increases due to additional build + Lighthouse audit.
- Rollback: revert this commit to remove Lighthouse job and assertion changes.

Closes #139