### PR TITLE
docs(runbooks): add per-service incident triage playbooks

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -15,6 +15,7 @@
 - [x] Observability baseline stubs (Prometheus alert rules, OTEL collector config)
 - [x] Observability baseline runbook
 - [x] Release rollback runbook
+- [x] Service incident triage playbooks per service (capability-registry, policy-engine, recipe-executor, digital-twin, site-registry)
 - [x] CI contract-tests gate (mainline + release workflows)
 - [x] Vitest coverage thresholds enforced repo-wide
 - [x] ADR index and phase-0 gap-report reconciled
@@ -24,7 +25,6 @@
 
 - Wire Prometheus alert rules into staging Prometheus instance (Phase 7)
 - Deploy OTEL collector config to staging (Phase 7)
-- Add service incident triage playbooks per service (Phase 7)
 - Safe-mode activation procedure runbook (Phase 7)
 - PLC interlock override checklist (Phase 7 — Security & Compliance)
 - Expand observability to include Grafana dashboard baselines

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,12 +11,17 @@ recovery, and safe-mode procedures.
 |---------|-------|--------|
 | [release-rollback.md](./release-rollback.md) | Production + staging Helm rollback, automated and manual rollback procedures | Active |
 | [observability-baseline.md](./observability-baseline.md) | Alert triage, availability, control-loop latency, audit log, policy engine, safety interlock procedures | Active |
+| [capability-registry-triage.md](./capability-registry-triage.md) | Incident triage for capability lifecycle, health checks, and registry recovery | Active |
+| [policy-engine-triage.md](./policy-engine-triage.md) | Incident triage for policy evaluation latency, decision anomalies, and safety escalation | Active |
+| [recipe-executor-triage.md](./recipe-executor-triage.md) | Incident triage for recipe execution failures, stalled progress, and safety-guarded recovery | Active |
+| [digital-twin-triage.md](./digital-twin-triage.md) | Incident triage for twin state ingestion, simulation failures, and sync lag recovery | Active |
+| [site-registry-triage.md](./site-registry-triage.md) | Incident triage for provisioning, feature flags, and federation topology integrity | Active |
 
 ## Related Guidance
 
 Operational guidance also lives in:
 
-- `.developer/RUNBOOKS/` — service-specific runbooks
+- `docs/runbooks/` — platform-wide and service-specific triage runbooks
 - `.developer/RELEASE.md` — full release checklist and rollback triggers
 - planning validation and closure records under `planning/`
 

--- a/docs/runbooks/capability-registry-triage.md
+++ b/docs/runbooks/capability-registry-triage.md
@@ -1,0 +1,88 @@
+# Runbook: Capability Registry Incident Triage
+
+**Risk Tier:** T1 (Mission-Critical)  
+**Service:** `@neurologix/capability-registry`  
+**Maintained by:** Platform Engineering  
+**Escalation:** On-call SRE -> Platform lead -> Safety/compliance officer
+
+---
+
+## Purpose
+
+This runbook defines first-responder triage for incidents affecting capability
+registration, capability health checks, and capability lifecycle operations.
+
+Use this runbook with:
+
+- [observability-baseline.md](./observability-baseline.md)
+- [release-rollback.md](./release-rollback.md)
+
+---
+
+## Trigger Symptoms
+
+- Capability install/update requests failing or timing out.
+- Capability list responses are stale or empty unexpectedly.
+- Health checks report elevated `isHealthy=false` outcomes.
+- Registry statistics drift from expected installed capability counts.
+
+---
+
+## Immediate Containment
+
+1. Confirm current service health and pod state:
+   ```bash
+   kubectl get pods -n neurologix -l app=capability-registry
+   kubectl logs -n neurologix deploy/capability-registry --tail=120
+   ```
+2. Stop non-critical capability change traffic until root cause is known
+   (freeze install/update operations).
+3. Notify mission-control operators that capability lifecycle actions are in
+   degraded mode.
+
+---
+
+## Service-Specific Diagnostics
+
+1. Validate contract behavior locally from repository state:
+   ```bash
+   npm run test:contracts --workspace @neurologix/capability-registry
+   ```
+2. Check for repeated lifecycle failures in logs (`install`, `update`,
+   `uninstall`, `health`).
+3. Verify dependency reachability for capability sources and registry endpoints.
+4. Confirm no sudden dependency break in shared packages:
+   ```bash
+   npm run build --workspace @neurologix/core
+   npm run build --workspace @neurologix/schemas
+   ```
+5. Compare observed responses with the service contract baseline in
+   `src/contracts/capability-registry.contract.test.ts`.
+
+---
+
+## Recovery and Rollback Criteria
+
+- Recover in-place when failures are isolated to one capability package and
+  registry process health is stable.
+- Trigger release rollback if registry error rate is sustained above SLO or
+  service does not stabilize within 5 minutes.
+- Follow [release-rollback.md](./release-rollback.md) for rollout reversal.
+
+---
+
+## Escalation and Compliance
+
+- Record incident timeline, impacted capabilities, and recovery action in
+  `.developer/INCIDENTS.md`.
+- If capability failures could affect safety enforcement paths, escalate as a
+  P1 and involve policy-engine owner immediately.
+- Preserve relevant structured logs for audit trail retention.
+
+---
+
+## Prevention
+
+- Keep contract baseline tests green in CI (`contract-tests` job).
+- Enforce capability package validation before enabling in production.
+- Review capability health trends and dependency errors weekly.

--- a/docs/runbooks/digital-twin-triage.md
+++ b/docs/runbooks/digital-twin-triage.md
@@ -1,0 +1,84 @@
+# Runbook: Digital Twin Incident Triage
+
+**Risk Tier:** T1 (Mission-Critical)  
+**Service:** `@neurologix/digital-twin`  
+**Maintained by:** Runtime Engineering  
+**Escalation:** On-call SRE -> Runtime lead -> Operations lead
+
+---
+
+## Purpose
+
+This runbook defines triage for incidents affecting digital twin state
+ingestion, simulation runs, and twin validation/statistics integrity.
+
+Use this runbook with:
+
+- [observability-baseline.md](./observability-baseline.md)
+- [release-rollback.md](./release-rollback.md)
+
+---
+
+## Trigger Symptoms
+
+- Twin state updates lag or stop arriving.
+- Simulation jobs fail repeatedly or produce invalid outputs.
+- Twin validation results unexpectedly degrade.
+- Mission-control shows stale or inconsistent twin state.
+
+---
+
+## Immediate Containment
+
+1. Confirm pod health and inspect recent logs:
+   ```bash
+   kubectl get pods -n neurologix -l app=digital-twin
+   kubectl logs -n neurologix deploy/digital-twin --tail=150
+   ```
+2. Pause non-essential simulation workloads until ingestion health is restored.
+3. Notify operators that twin-backed views are in degraded mode.
+
+---
+
+## Service-Specific Diagnostics
+
+1. Validate digital-twin contract baseline:
+   ```bash
+   npm run test:contracts --workspace @neurologix/digital-twin
+   ```
+2. Validate required shared package builds:
+   ```bash
+   npm run build --workspace @neurologix/core
+   npm run build --workspace @neurologix/schemas
+   ```
+3. Inspect state-ingestion events by `twinId` and source (`telemetry`, `manual`).
+4. Check simulation run status and step progression for recent failed runs.
+5. Compare observed behavior to contracts in
+   `src/contracts/digital-twin.contract.test.ts`.
+
+---
+
+## Recovery and Rollback Criteria
+
+- Recover in-place for isolated asset/twin corruption after targeted reingest.
+- Trigger rollback if platform-wide twin sync lag persists above SLO or
+  simulations fail broadly after release.
+- Execute rollback with [release-rollback.md](./release-rollback.md).
+
+---
+
+## Escalation and Compliance
+
+- Record affected twins, asset IDs, and operator-facing impact in
+  `.developer/INCIDENTS.md`.
+- If state drift can influence safety decisions, escalate to policy and safety
+  owners immediately.
+- Preserve telemetry and audit evidence linked to the incident window.
+
+---
+
+## Prevention
+
+- Keep contract baseline and state/simulation regression tests green.
+- Track digital twin sync lag and state-ingestion error trends.
+- Review asset onboarding quality for required metadata and validation rules.

--- a/docs/runbooks/policy-engine-triage.md
+++ b/docs/runbooks/policy-engine-triage.md
@@ -1,0 +1,83 @@
+# Runbook: Policy Engine Incident Triage
+
+**Risk Tier:** T1 (Mission-Critical)  
+**Service:** `@neurologix/policy-engine`  
+**Maintained by:** Platform Engineering + Security  
+**Escalation:** On-call SRE -> Security lead -> Compliance officer
+
+---
+
+## Purpose
+
+This runbook defines triage for policy decision latency, deny/allow anomalies,
+and policy evaluation failures in the policy engine.
+
+Use this runbook with:
+
+- [observability-baseline.md](./observability-baseline.md)
+- [release-rollback.md](./release-rollback.md)
+
+---
+
+## Trigger Symptoms
+
+- Policy decision latency p95 breaches (target < 10ms).
+- Sudden spikes in denied decisions for known-valid requests.
+- Recipe execution blocked waiting for policy decisions.
+- Audit trail generation or integrity checks fail.
+
+---
+
+## Immediate Containment
+
+1. Confirm service and pod health:
+   ```bash
+   kubectl get pods -n neurologix -l app=policy-engine
+   kubectl logs -n neurologix deploy/policy-engine --tail=150
+   ```
+2. Pause high-risk autonomous operations if policy behavior is inconsistent.
+3. Route operations to safe manual-override mode per control-room procedures.
+
+---
+
+## Service-Specific Diagnostics
+
+1. Validate policy-engine contract baseline:
+   ```bash
+   npm run test:contracts --workspace @neurologix/policy-engine
+   ```
+2. Validate dependency packages used by contract script:
+   ```bash
+   npm run build --workspace @neurologix/core
+   npm run build --workspace @neurologix/security-core
+   npm run build --workspace @neurologix/schemas
+   ```
+3. Inspect policy-evaluation error patterns and `requestId` correlation in logs.
+4. Verify default decision mode and emergency-mode config are as expected.
+5. Check for recent policy bundle or rule changes causing behavior drift.
+
+---
+
+## Recovery and Rollback Criteria
+
+- Recover in-place if issue is from a single policy document and can be safely
+  reverted without platform rollback.
+- Trigger release rollback when policy latency/decision anomalies persist more
+  than 5 minutes or affect safety-critical workflows.
+- Follow [release-rollback.md](./release-rollback.md) when rollback is required.
+
+---
+
+## Escalation and Compliance
+
+- Treat safety-interlock bypass attempts as immediate P0 incidents.
+- Log incident details and policy IDs involved in `.developer/INCIDENTS.md`.
+- Preserve policy decision audit evidence for IEC 62443 / ISO 27001 review.
+
+---
+
+## Prevention
+
+- Require contract + policy regression tests for all policy changes.
+- Keep policy metadata complete (author, tags, category, priority).
+- Monitor policy decision latency and error-rate alerts continuously.

--- a/docs/runbooks/recipe-executor-triage.md
+++ b/docs/runbooks/recipe-executor-triage.md
@@ -1,0 +1,83 @@
+# Runbook: Recipe Executor Incident Triage
+
+**Risk Tier:** T1 (Mission-Critical)  
+**Service:** `@neurologix/recipe-executor`  
+**Maintained by:** Runtime Engineering  
+**Escalation:** On-call SRE -> Runtime lead -> Safety engineer
+
+---
+
+## Purpose
+
+This runbook defines triage for incidents impacting recipe orchestration,
+execution progress, safety checks, and execution statistics integrity.
+
+Use this runbook with:
+
+- [observability-baseline.md](./observability-baseline.md)
+- [release-rollback.md](./release-rollback.md)
+
+---
+
+## Trigger Symptoms
+
+- Recipe execution failures increase above normal baseline.
+- Executions stall in non-terminal states or progress stops.
+- Safety check handling appears inconsistent with expected behavior.
+- Recent execution statistics diverge from observed operator actions.
+
+---
+
+## Immediate Containment
+
+1. Confirm service state and inspect recent logs:
+   ```bash
+   kubectl get pods -n neurologix -l app=recipe-executor
+   kubectl logs -n neurologix deploy/recipe-executor --tail=150
+   ```
+2. Suspend non-essential recipe dispatches from mission-control.
+3. Keep hardware interlock protections active; do not bypass safety checks.
+
+---
+
+## Service-Specific Diagnostics
+
+1. Validate recipe-executor contract baseline:
+   ```bash
+   npm run test:contracts --workspace @neurologix/recipe-executor
+   ```
+2. Re-check shared package builds used by contract tests:
+   ```bash
+   npm run build --workspace @neurologix/core
+   npm run build --workspace @neurologix/schemas
+   ```
+3. Inspect failed executions by `executionId` and `recipeId` in logs.
+4. Verify failures are not caused by policy-engine dependency latency/outage.
+5. Confirm expected status transitions against `RecipeExecutionStatus` contract.
+
+---
+
+## Recovery and Rollback Criteria
+
+- Recover in-place if failures are tied to a specific recipe definition that can
+  be disabled safely.
+- Trigger release rollback for systemic execution failure spikes, prolonged
+  execution stalls, or inability to guarantee safety guardrails.
+- Use [release-rollback.md](./release-rollback.md) for rollback sequence.
+
+---
+
+## Escalation and Compliance
+
+- For safety-critical execution anomalies, escalate immediately to safety owner.
+- Record impacted recipe IDs, execution IDs, and timeline in
+  `.developer/INCIDENTS.md`.
+- Ensure all actions remain traceable through immutable audit logs.
+
+---
+
+## Prevention
+
+- Keep contract baseline and execution regression tests green in CI.
+- Validate recipe definitions before deployment.
+- Monitor recipe failure-rate alerts and execution latency trends.

--- a/docs/runbooks/site-registry-triage.md
+++ b/docs/runbooks/site-registry-triage.md
@@ -1,0 +1,87 @@
+# Runbook: Site Registry Incident Triage
+
+**Risk Tier:** T1 (Mission-Critical)  
+**Service:** `@neurologix/site-registry`  
+**Maintained by:** Federation Platform Team  
+**Escalation:** On-call SRE -> Federation lead -> Compliance officer
+
+---
+
+## Purpose
+
+This runbook defines triage for incidents affecting site lifecycle management,
+feature-flag updates, and federation topology integrity.
+
+Use this runbook with:
+
+- [observability-baseline.md](./observability-baseline.md)
+- [release-rollback.md](./release-rollback.md)
+
+---
+
+## Trigger Symptoms
+
+- Site creation/status transition operations fail unexpectedly.
+- Feature-flag upserts fail or return inconsistent data.
+- Federation topology responses are stale or malformed.
+- Duplicate slug or contract mismatch errors spike unexpectedly.
+
+---
+
+## Immediate Containment
+
+1. Verify service health and capture recent logs:
+   ```bash
+   kubectl get pods -n neurologix -l app=site-registry
+   kubectl logs -n neurologix deploy/site-registry --tail=150
+   ```
+2. Pause non-critical provisioning and bulk status transitions.
+3. Communicate temporary provisioning degradation to operations teams.
+
+---
+
+## Service-Specific Diagnostics
+
+1. Validate site-registry contract baseline:
+   ```bash
+   npm run test:contracts --workspace @neurologix/site-registry
+   ```
+2. Re-validate federation contract endpoints locally:
+   - `GET /api/sites`
+   - `POST /api/sites`
+   - `PATCH /api/sites/:siteId/status`
+   - `PUT /api/feature-flags/:key`
+   - `GET /api/federation`
+3. Inspect error-code distribution, especially `DUPLICATE_SLUG` and status
+   transition validation failures.
+4. Confirm topology response still validates against
+   `FederationTopologySchema`.
+5. Compare incident payloads against request/response schemas in
+   `@neurologix/schemas`.
+
+---
+
+## Recovery and Rollback Criteria
+
+- Recover in-place for isolated invalid input cases or single-site data
+  correction needs.
+- Trigger rollback if provisioning failures are systemic or federation topology
+  contract integrity is broken after deployment.
+- Use [release-rollback.md](./release-rollback.md) for rollback execution.
+
+---
+
+## Escalation and Compliance
+
+- Record impacted site IDs/slugs, feature flags, and timeline in
+  `.developer/INCIDENTS.md`.
+- Escalate federation-wide data integrity incidents as P1.
+- Preserve logs and topology snapshots for post-incident audit.
+
+---
+
+## Prevention
+
+- Keep site-registry contract tests in CI and monitor schema drift.
+- Enforce strict slug uniqueness and validated status transitions.
+- Periodically verify federation topology contract conformance.


### PR DESCRIPTION
## Summary
- add five service incident triage playbooks for core runtime services
- update runbook index in docs/runbooks/README.md
- mark .developer/TODO.md triage-playbook gap as completed

## Scope
- docs-only, no runtime code or CI behavior changes

## Validation
- 
pm run lint (pass; existing warnings only)
- 
pm run type-check (pass)

Closes #141