### PR TITLE
docs: add Grafana dashboard baseline stubs and runbook alignment

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -13,6 +13,7 @@
 - [x] Federation API endpoints (SITE-005, FF-002, FF-003) — all 9 FEDERATION_API_CONTRACTS covered
 - [x] ADR-010 contract testing strategy documented
 - [x] Observability baseline stubs (Prometheus alert rules, OTEL collector config)
+- [x] Grafana dashboard baseline stubs (control-plane, security-audit, mission-control-ui)
 - [x] Observability baseline runbook
 - [x] Release rollback runbook
 - [x] Service incident triage playbooks per service (capability-registry, policy-engine, recipe-executor, digital-twin, site-registry)
@@ -27,7 +28,7 @@
 
 - Wire Prometheus alert rules into staging Prometheus instance (Phase 7)
 - Deploy OTEL collector config to staging (Phase 7)
-- Expand observability to include Grafana dashboard baselines
+- Import and wire Grafana dashboard baselines in staging (Phase 7)
 
 ## Quality Targets
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -25,6 +25,7 @@ Operational guidance also lives in:
 
 - `docs/runbooks/` — platform-wide and service-specific triage runbooks
 - `.developer/RELEASE.md` — full release checklist and rollback triggers
+- `infrastructure/observability/grafana/` — baseline Grafana dashboard stubs aligned to OBS-001
 - planning validation and closure records under `planning/`
 
 ## Near-Term Contents

--- a/docs/runbooks/observability-baseline.md
+++ b/docs/runbooks/observability-baseline.md
@@ -16,6 +16,25 @@ baseline alert rules. Each section maps to one or more Prometheus alert rules.
 For release-specific rollback procedures, see
 [release-rollback.md](./release-rollback.md).
 
+## Dashboard Baselines
+
+The baseline Grafana dashboard stubs are versioned at:
+
+- `infrastructure/observability/grafana/control-plane.dashboard.json`
+- `infrastructure/observability/grafana/security-audit.dashboard.json`
+- `infrastructure/observability/grafana/mission-control-ui.dashboard.json`
+
+Use these dashboards with this runbook as follows:
+
+- `control-plane` dashboard supports control-loop latency, throughput, recipe success,
+   and safety event triage.
+- `security-audit` dashboard supports audit write failure, policy denied/blocked event,
+   and safety bypass triage.
+- `mission-control-ui` dashboard supports mission-control SLO visibility
+   (LCP p95, SSE stream uptime, error rate by route).
+
+Import and datasource wiring are environment tasks tracked in `.developer/TODO.md`.
+
 ---
 
 ## Availability Breach
@@ -308,6 +327,7 @@ direct T1 SLO breach and a compliance event under IEC 62443 / ISO 27001.
 
 - [Prometheus Alert Rules](../../infrastructure/observability/prometheus-alerts.yml)
 - [OTEL Collector Config](../../infrastructure/observability/otel-collector-config.yaml)
+- [Grafana Dashboard Baselines](../../infrastructure/observability/grafana/README.md)
 - [Release Rollback Runbook](./release-rollback.md)
 - [Observability Model (OBS-001)](../../.github/.system-state/ops/observability_model.yaml)
 - [ADR-004: Observability Strategy](../architecture/ADR-004-observability-strategy.md)

--- a/infrastructure/observability/README.md
+++ b/infrastructure/observability/README.md
@@ -9,12 +9,13 @@ NeuroLogix platform.
 |---|---|
 | `prometheus-alerts.yml` | Prometheus alerting rules for all T1 SLOs (OBS-001) |
 | `otel-collector-config.yaml` | OpenTelemetry Collector configuration stub |
+| `grafana/*.dashboard.json` | Grafana dashboard baseline stubs aligned to OBS-001 dashboard panel intent |
 
 ## Status
 
 **Baseline stub** — these files define the target configuration. They must be
-wired into live Prometheus and the OTEL collector deployment in **Phase 7
-(Security & Compliance)**.
+wired into live Prometheus, OTEL collector deployment, and Grafana provisioning
+in **Phase 7 (Security & Compliance)**.
 
 ## Architecture
 
@@ -57,4 +58,5 @@ Derived from `.github/.system-state/ops/observability_model.yaml` (OBS-001):
 
 - [Observability Strategy (ADR-004)](../../docs/architecture/ADR-004-observability-strategy.md)
 - [Observability Baseline Runbook](../../docs/runbooks/observability-baseline.md)
+- [Grafana Dashboard Baselines](./grafana/README.md)
 - [OBS-001 Model](../../.github/.system-state/ops/observability_model.yaml)

--- a/infrastructure/observability/grafana/README.md
+++ b/infrastructure/observability/grafana/README.md
@@ -1,0 +1,27 @@
+# Grafana Dashboard Baselines
+
+These dashboard files provide **versioned baseline stubs** for the dashboard
+definitions in `.github/.system-state/ops/observability_model.yaml` (`OBS-001`).
+
+## Files
+
+| File | OBS-001 dashboard key | Purpose |
+|---|---|---|
+| `control-plane.dashboard.json` | `control_plane` | Control-loop latency, throughput, recipe success, safety interlock events |
+| `security-audit.dashboard.json` | `security_audit` | Audit write errors, policy denied/blocked events, safety bypass, certificate expiry |
+| `mission-control-ui.dashboard.json` | `mission_control_ui` | LCP p95, SSE stream uptime, route-level error rates |
+
+## Usage
+
+1. Import dashboard JSON into Grafana in a staging workspace.
+2. Bind datasource variable placeholders (for example `DS_PROMETHEUS`) to the
+   environment's Prometheus datasource.
+3. Validate panel queries against emitted metrics before production rollout.
+
+## Notes
+
+- These are **baseline stubs**, not deployment automation.
+- Runtime provisioning to staging/production remains tracked in
+  `.developer/TODO.md`.
+- Alert triage procedures are documented in
+  `docs/runbooks/observability-baseline.md`.

--- a/infrastructure/observability/grafana/control-plane.dashboard.json
+++ b/infrastructure/observability/grafana/control-plane.dashboard.json
@@ -1,0 +1,137 @@
+{
+  "uid": "neurologix-control-plane-baseline",
+  "title": "NeuroLogix - Control Plane Baseline",
+  "tags": ["neurologix", "phase7", "baseline", "control-plane"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(http_requests_total, service)",
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Control Loop Latency p95 / p99",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(control_loop_duration_seconds_bucket[1m]))) * 1000",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(control_loop_duration_seconds_bucket[1m]))) * 1000",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Tag Throughput",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(tag_ingest_total[1m]))",
+          "legendFormat": "tags/s"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Recipe Execution Success Rate",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(recipe_executions_total{outcome=\"success\"}[5m])) / sum(rate(recipe_executions_total[5m]))"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Safety Interlock Events",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "increase(safety_interlock_bypass_attempts_total[5m])"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/observability/grafana/mission-control-ui.dashboard.json
+++ b/infrastructure/observability/grafana/mission-control-ui.dashboard.json
@@ -1,0 +1,89 @@
+{
+  "uid": "neurologix-mission-control-ui-baseline",
+  "title": "NeuroLogix - Mission Control UI Baseline",
+  "tags": ["neurologix", "phase7", "baseline", "mission-control", "ui"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "LCP p95",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(web_vitals_lcp_seconds_bucket[5m]))) * 1000",
+          "legendFormat": "lcp_p95_ms"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "SSE Stream Uptime",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(sse_connection_success_total[5m])) / clamp_min(sum(rate(sse_connection_attempts_total[5m])), 1)"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Error Rate by Route",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route) (rate(http_requests_total{status=~\"5..\", service=\"mission-control\"}[5m])) / clamp_min(sum by (route) (rate(http_requests_total{service=\"mission-control\"}[5m])), 1)",
+          "legendFormat": "{{route}}"
+        }
+      ]
+    }
+  ]
+}

--- a/infrastructure/observability/grafana/security-audit.dashboard.json
+++ b/infrastructure/observability/grafana/security-audit.dashboard.json
@@ -1,0 +1,114 @@
+{
+  "uid": "neurologix-security-audit-baseline",
+  "title": "NeuroLogix - Security & Audit Baseline",
+  "tags": ["neurologix", "phase7", "baseline", "security", "audit"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Audit Log Write Error Rate",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(audit_writes_total{outcome=\"error\"}[1m]))",
+          "legendFormat": "errors/s"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Policy Denied Events",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(policy_decisions_total{outcome=~\"denied|blocked\"}[5m]))",
+          "legendFormat": "denied_or_blocked/s"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Safety Bypass Events",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "increase(safety_interlock_bypass_attempts_total[1h])"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Certificate Expiry Countdown",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min(certificate_expiry_days)",
+          "legendFormat": "days_to_expiry"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add OBS-001-aligned Grafana dashboard baseline stubs for `control_plane`, `security_audit`, and `mission_control_ui`
- document dashboard baseline usage in observability infrastructure and runbook docs
- update developer TODO to mark dashboard baseline stubs complete and track staging wiring as next step

## Linked Issue
Closes #147

## Validation
- `node -e "const fs=require('fs');['infrastructure/observability/grafana/control-plane.dashboard.json','infrastructure/observability/grafana/security-audit.dashboard.json','infrastructure/observability/grafana/mission-control-ui.dashboard.json'].forEach(f=>JSON.parse(fs.readFileSync(f,'utf8'))); console.log('Grafana dashboard JSON validation: PASS');"`
- `npm run lint`
- `npm run type-check`
