### PR TITLE
Phase 7: add staging observability wiring baselines

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -23,12 +23,11 @@
 - [x] Lighthouse CI gate for mission-control in mainline CI
 - [x] Safe-mode activation procedure runbook (Phase 7)
 - [x] PLC interlock override checklist runbook (Phase 7)
+- [x] Staging observability wiring artifact baseline (Prometheus alert integration values, OTEL collector deployment baseline, Grafana provisioning baseline)
 
 ## Active / Near Term
 
-- Wire Prometheus alert rules into staging Prometheus instance (Phase 7)
-- Deploy OTEL collector config to staging (Phase 7)
-- Import and wire Grafana dashboard baselines in staging (Phase 7)
+- Apply staging observability wiring artifacts and capture rollout evidence in staging (Phase 7)
 
 ## Quality Targets
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,7 @@ recovery, and safe-mode procedures.
 |---------|-------|--------|
 | [release-rollback.md](./release-rollback.md) | Production + staging Helm rollback, automated and manual rollback procedures | Active |
 | [observability-baseline.md](./observability-baseline.md) | Alert triage, availability, control-loop latency, audit log, policy engine, safety interlock procedures | Active |
+| [observability-staging-wiring.md](./observability-staging-wiring.md) | Staging wiring procedure for Prometheus alert rules, OTEL collector deployment baseline, and Grafana provisioning baseline | Active |
 | [capability-registry-triage.md](./capability-registry-triage.md) | Incident triage for capability lifecycle, health checks, and registry recovery | Active |
 | [policy-engine-triage.md](./policy-engine-triage.md) | Incident triage for policy evaluation latency, decision anomalies, and safety escalation | Active |
 | [recipe-executor-triage.md](./recipe-executor-triage.md) | Incident triage for recipe execution failures, stalled progress, and safety-guarded recovery | Active |

--- a/docs/runbooks/observability-baseline.md
+++ b/docs/runbooks/observability-baseline.md
@@ -33,7 +33,8 @@ Use these dashboards with this runbook as follows:
 - `mission-control-ui` dashboard supports mission-control SLO visibility
    (LCP p95, SSE stream uptime, error rate by route).
 
-Import and datasource wiring are environment tasks tracked in `.developer/TODO.md`.
+Import and datasource wiring procedures are documented in
+[observability-staging-wiring.md](./observability-staging-wiring.md).
 
 ---
 

--- a/docs/runbooks/observability-staging-wiring.md
+++ b/docs/runbooks/observability-staging-wiring.md
@@ -1,0 +1,90 @@
+# Runbook: Observability Staging Wiring
+
+**Risk Tier:** T1 (Mission-Critical)  
+**Maintained by:** Platform Engineering  
+**Escalation:** SRE on-call → Platform owner  
+**Model Source:** `.github/.system-state/ops/observability_model.yaml` (OBS-001)
+
+---
+
+## Overview
+
+This runbook defines the staging procedure for wiring the existing observability
+baselines into a deployable environment:
+
+- Prometheus alert rules (`infrastructure/observability/prometheus-alerts.yml`)
+- OTEL collector config (`infrastructure/observability/otel-collector-config.yaml`)
+- Grafana dashboard baselines (`infrastructure/observability/grafana/*.dashboard.json`)
+
+Deployment baseline artifacts are in `infrastructure/observability/staging/`.
+
+---
+
+## Preconditions
+
+- Kubernetes staging namespace exists: `neurologix-observability`
+- Helm repositories available:
+  - `prometheus-community`
+  - `grafana`
+- Baseline observability files committed on target revision
+
+---
+
+## Procedure
+
+1. Apply staging wiring bundle:
+
+   ```bash
+   kubectl apply -k infrastructure/observability/staging
+   ```
+
+2. Deploy/upgrade Prometheus with NeuroLogix alert rule mounts:
+
+   ```bash
+   helm upgrade --install prometheus prometheus-community/prometheus \
+     --namespace neurologix-observability \
+     -f infrastructure/observability/staging/prometheus.values.staging.yaml
+   ```
+
+3. Deploy/upgrade Grafana with provisioning + dashboard mounts:
+
+   ```bash
+   helm upgrade --install grafana grafana/grafana \
+     --namespace neurologix-observability \
+     -f infrastructure/observability/staging/grafana.values.staging.yaml
+   ```
+
+4. Verify OTEL collector deployment:
+
+   ```bash
+   kubectl get deploy -n neurologix-observability otel-collector
+   kubectl logs -n neurologix-observability deploy/otel-collector --tail=100
+   ```
+
+---
+
+## Verification Checklist
+
+- `neurologix-prometheus-alert-rules` ConfigMap exists in namespace.
+- `neurologix-otel-collector-config` ConfigMap exists and is mounted by OTEL collector.
+- `neurologix-grafana-dashboards` and `neurologix-grafana-provisioning` ConfigMaps exist.
+- Prometheus loads NeuroLogix alert rules without syntax errors.
+- Grafana shows datasources `Prometheus` and `Jaeger`.
+- Grafana dashboard provider `neurologix-observability` is active.
+- Baseline dashboards (`control-plane`, `security-audit`, `mission-control-ui`) render.
+
+---
+
+## Failure Handling
+
+- If Prometheus fails after values rollout, revert to prior release revision:
+
+  ```bash
+  helm rollback prometheus <REVISION> -n neurologix-observability
+  ```
+
+- If Grafana provisioning fails, rollback release and verify provisioning file mounts.
+- If OTEL collector fails health checks, inspect env var and endpoint wiring first.
+
+For broader release rollback procedures, use
+`docs/runbooks/release-rollback.md`.

--- a/infrastructure/observability/README.md
+++ b/infrastructure/observability/README.md
@@ -10,6 +10,7 @@ NeuroLogix platform.
 | `prometheus-alerts.yml` | Prometheus alerting rules for all T1 SLOs (OBS-001) |
 | `otel-collector-config.yaml` | OpenTelemetry Collector configuration stub |
 | `grafana/*.dashboard.json` | Grafana dashboard baseline stubs aligned to OBS-001 dashboard panel intent |
+| `staging/` | Staging wiring artifacts for Prometheus alert integration, OTEL collector deployment, and Grafana provisioning |
 
 ## Status
 
@@ -26,6 +27,16 @@ Services (OTLP) ──► otel-collector ──► Jaeger (traces)
 Prometheus ◄── scraped /metrics endpoints (all services)
 Prometheus ──► Alertmanager ──► PagerDuty / OpsGenie
 ```
+
+## Staging Wiring Baseline
+
+Use the staging wiring baseline to connect the existing observability stubs into
+a staging environment:
+
+- [Staging wiring baseline guide](./staging/README.md)
+- [Kustomize wiring bundle](./staging/kustomization.yaml)
+- [Prometheus values baseline](./staging/prometheus.values.staging.yaml)
+- [Grafana values baseline](./staging/grafana.values.staging.yaml)
 
 ## SLOs Covered by Alert Rules
 

--- a/infrastructure/observability/staging/README.md
+++ b/infrastructure/observability/staging/README.md
@@ -1,0 +1,59 @@
+# Staging Observability Wiring Baseline
+
+This directory provides staging wiring artifacts for the existing observability
+baselines in `infrastructure/observability/`.
+
+## Artifacts
+
+- `kustomization.yaml` — generates ConfigMaps from canonical baseline files:
+  - `../prometheus-alerts.yml`
+  - `../otel-collector-config.yaml`
+  - `../grafana/*.dashboard.json`
+- `otel-collector.deployment.yaml` — baseline OTEL collector deployment for staging.
+- `grafana-provisioning.configmap.yaml` — Grafana datasource and dashboard provider provisioning baseline.
+- `prometheus.values.staging.yaml` — Helm values baseline for Prometheus alert rule mounting.
+- `grafana.values.staging.yaml` — Helm values baseline for Grafana provisioning/dashboard mounts.
+
+## Apply Sequence (Staging)
+
+1. Generate and apply baseline ConfigMaps + OTEL deployment + Grafana provisioning:
+
+   ```bash
+   kubectl apply -k infrastructure/observability/staging
+   ```
+
+2. Apply Prometheus chart values baseline:
+
+   ```bash
+   helm upgrade --install prometheus prometheus-community/prometheus \
+     --namespace neurologix-observability \
+     -f infrastructure/observability/staging/prometheus.values.staging.yaml
+   ```
+
+3. Apply Grafana chart values baseline:
+
+   ```bash
+   helm upgrade --install grafana grafana/grafana \
+     --namespace neurologix-observability \
+     -f infrastructure/observability/staging/grafana.values.staging.yaml
+   ```
+
+## Verification
+
+```bash
+kubectl get configmap -n neurologix-observability | grep neurologix-
+kubectl get deploy -n neurologix-observability otel-collector
+kubectl logs -n neurologix-observability deploy/otel-collector --tail=50
+```
+
+Grafana checks:
+
+- Datasources include `Prometheus` and `Jaeger`.
+- Dashboard provider `neurologix-observability` is present.
+- Baseline dashboards render without query errors.
+
+## Notes
+
+- These files are deployment baselines only; environment-specific endpoints,
+  credentials, and TLS hardening are handled per-environment.
+- Follow incident procedures in `docs/runbooks/observability-baseline.md`.

--- a/infrastructure/observability/staging/grafana-provisioning.configmap.yaml
+++ b/infrastructure/observability/staging/grafana-provisioning.configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neurologix-grafana-provisioning
+  namespace: neurologix-observability
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: neurologix
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus-server.neurologix-observability.svc.cluster.local:9090
+        isDefault: true
+        editable: false
+      - name: Jaeger
+        uid: jaeger
+        type: jaeger
+        access: proxy
+        url: http://jaeger-query.neurologix-observability.svc.cluster.local:16686
+        editable: false
+
+  dashboard-providers.yaml: |
+    apiVersion: 1
+    providers:
+      - name: neurologix-observability
+        orgId: 1
+        type: file
+        disableDeletion: true
+        editable: false
+        updateIntervalSeconds: 30
+        options:
+          path: /var/lib/grafana/dashboards/neurologix

--- a/infrastructure/observability/staging/grafana.values.staging.yaml
+++ b/infrastructure/observability/staging/grafana.values.staging.yaml
@@ -1,0 +1,19 @@
+# Baseline values for grafana/grafana Helm chart in staging.
+# Mounts provisioning and dashboard ConfigMaps created by `kubectl apply -k`.
+
+extraConfigmapMounts:
+  - name: neurologix-grafana-provisioning
+    configMap: neurologix-grafana-provisioning
+    mountPath: /etc/grafana/provisioning
+    readOnly: true
+
+  - name: neurologix-grafana-dashboards
+    configMap: neurologix-grafana-dashboards
+    mountPath: /var/lib/grafana/dashboards/neurologix
+    readOnly: true
+
+sidecar:
+  dashboards:
+    enabled: false
+  datasources:
+    enabled: false

--- a/infrastructure/observability/staging/kustomization.yaml
+++ b/infrastructure/observability/staging/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: neurologix-observability
+
+commonLabels:
+  app.kubernetes.io/part-of: neurologix
+  app.kubernetes.io/component: observability
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: neurologix-prometheus-alert-rules
+    files:
+      - prometheus-alerts.yml=../prometheus-alerts.yml
+  - name: neurologix-otel-collector-config
+    files:
+      - otel-collector-config.yaml=../otel-collector-config.yaml
+  - name: neurologix-grafana-dashboards
+    files:
+      - control-plane.dashboard.json=../grafana/control-plane.dashboard.json
+      - security-audit.dashboard.json=../grafana/security-audit.dashboard.json
+      - mission-control-ui.dashboard.json=../grafana/mission-control-ui.dashboard.json
+
+resources:
+  - otel-collector.deployment.yaml
+  - grafana-provisioning.configmap.yaml

--- a/infrastructure/observability/staging/otel-collector.deployment.yaml
+++ b/infrastructure/observability/staging/otel-collector.deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: neurologix-observability
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/part-of: neurologix
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+        app.kubernetes.io/part-of: neurologix
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.95.0
+          args:
+            - --config=/conf/otel-collector-config.yaml
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 8888
+              name: otel-metrics
+            - containerPort: 13133
+              name: healthz
+          env:
+            - name: DEPLOY_ENV
+              value: staging
+            - name: CLOUD_REGION
+              value: local
+            - name: JAEGER_ENDPOINT
+              value: jaeger-collector.neurologix-observability.svc.cluster.local:4317
+            - name: PROMETHEUS_REMOTE_WRITE_ENDPOINT
+              value: http://prometheus-server.neurologix-observability.svc.cluster.local:9090/api/v1/write
+            - name: ELASTICSEARCH_ENDPOINT
+              value: http://elasticsearch.neurologix-observability.svc.cluster.local:9200
+            - name: ELASTICSEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: observability-elk-credentials
+                  key: username
+                  optional: true
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: observability-elk-credentials
+                  key: password
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: otel-config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: otel-config
+          configMap:
+            name: neurologix-otel-collector-config
+            items:
+              - key: otel-collector-config.yaml
+                path: otel-collector-config.yaml

--- a/infrastructure/observability/staging/prometheus.values.staging.yaml
+++ b/infrastructure/observability/staging/prometheus.values.staging.yaml
@@ -1,0 +1,15 @@
+# Baseline values for prometheus-community/prometheus Helm chart in staging.
+# This mounts the generated alert rules ConfigMap created by `kubectl apply -k`.
+
+server:
+  extraConfigmapMounts:
+    - name: neurologix-alert-rules
+      configMap: neurologix-prometheus-alert-rules
+      mountPath: /etc/prometheus/neurologix-rules
+      readOnly: true
+
+  # Include NeuroLogix OBS-001 alert rules in Prometheus startup flags.
+  extraFlags:
+    - web.enable-lifecycle
+    - rule.file=/etc/prometheus/config/*.yml
+    - rule.file=/etc/prometheus/neurologix-rules/*.yml


### PR DESCRIPTION
## Summary
Implements Issue #149 by adding a minimal staging wiring baseline for observability runtime artifacts.

## What changed
- Added infrastructure/observability/staging/ baseline artifacts:
  - kustomization.yaml (generates ConfigMaps from canonical baseline files)
  - otel-collector.deployment.yaml (staging OTEL collector deployment baseline)
  - grafana-provisioning.configmap.yaml (datasource/provider provisioning baseline)
  - prometheus.values.staging.yaml (Prometheus alert-rule integration values)
  - grafana.values.staging.yaml (Grafana provisioning/dashboard mount values)
  - README.md (staging apply and verification flow)
- Added runbook: docs/runbooks/observability-staging-wiring.md
- Updated references:
  - infrastructure/observability/README.md
  - docs/runbooks/README.md
  - docs/runbooks/observability-baseline.md
  - .developer/TODO.md

## Validation
- 
pm run lint
- 
pm run type-check

## Scope Notes
- Additive/staging baseline only; no production rollout automation or runtime secret implementation.

Closes #149