### PR TITLE
docs: add staging observability rollout evidence scaffold

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -24,10 +24,11 @@
 - [x] Safe-mode activation procedure runbook (Phase 7)
 - [x] PLC interlock override checklist runbook (Phase 7)
 - [x] Staging observability wiring artifact baseline (Prometheus alert integration values, OTEL collector deployment baseline, Grafana provisioning baseline)
+- [x] Staging observability rollout evidence scaffold (required verification template + runbook linkage)
 
 ## Active / Near Term
 
-- Apply staging observability wiring artifacts and capture rollout evidence in staging (Phase 7)
+- Execute first staging rollout and attach filled observability evidence record in `planning/` (Phase 7)
 
 ## Quality Targets
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -12,6 +12,7 @@ recovery, and safe-mode procedures.
 | [release-rollback.md](./release-rollback.md) | Production + staging Helm rollback, automated and manual rollback procedures | Active |
 | [observability-baseline.md](./observability-baseline.md) | Alert triage, availability, control-loop latency, audit log, policy engine, safety interlock procedures | Active |
 | [observability-staging-wiring.md](./observability-staging-wiring.md) | Staging wiring procedure for Prometheus alert rules, OTEL collector deployment baseline, and Grafana provisioning baseline | Active |
+| [observability-staging-rollout-evidence.md](./observability-staging-rollout-evidence.md) | Required evidence template for staging rollout verification of Prometheus, OTEL, and Grafana wiring | Active |
 | [capability-registry-triage.md](./capability-registry-triage.md) | Incident triage for capability lifecycle, health checks, and registry recovery | Active |
 | [policy-engine-triage.md](./policy-engine-triage.md) | Incident triage for policy evaluation latency, decision anomalies, and safety escalation | Active |
 | [recipe-executor-triage.md](./recipe-executor-triage.md) | Incident triage for recipe execution failures, stalled progress, and safety-guarded recovery | Active |
@@ -31,7 +32,7 @@ Operational guidance also lives in:
 
 ## Near-Term Contents
 
-- No pending runbook-only gaps; near-term delivery tracked in `.developer/TODO.md`.
+- Execute a staging rollout using `observability-staging-wiring.md` and capture a filled evidence record from `observability-staging-rollout-evidence.md` under `planning/`.
 
 ## Related Architecture Evidence
 

--- a/docs/runbooks/observability-staging-rollout-evidence.md
+++ b/docs/runbooks/observability-staging-rollout-evidence.md
@@ -1,0 +1,98 @@
+# Runbook Template: Observability Staging Rollout Evidence
+
+**Purpose:** Capture auditable evidence for a single staging rollout of observability wiring.
+
+Use this template for every rollout execution from `docs/runbooks/observability-staging-wiring.md`.
+Store filled records in `planning/` with a date and issue/PR reference.
+
+---
+
+## Rollout Metadata
+
+- **Environment:** staging
+- **Date (UTC):**
+- **Start Time (UTC):**
+- **End Time (UTC):**
+- **Operator / Owner:**
+- **Issue / PR:**
+- **Git SHA / Revision:**
+- **Namespace:** `neurologix-observability`
+- **Overall Status:** PASS / FAIL / PARTIAL
+
+---
+
+## Change Inputs
+
+- `kubectl apply -k infrastructure/observability/staging` executed: YES / NO
+- Prometheus release revision (before → after):
+- Grafana release revision (before → after):
+- OTEL collector image/tag:
+
+---
+
+## Prometheus Verification (Alert Rule Load)
+
+### Required Checks
+
+- [ ] `neurologix-prometheus-alert-rules` ConfigMap present.
+- [ ] Prometheus server logs show successful rule load (no syntax/parsing errors).
+- [ ] Target NeuroLogix alert groups visible/loaded.
+
+### Evidence
+
+- Command output references:
+- Log excerpt references:
+- Notes:
+- **Status:** PASS / FAIL / PARTIAL
+
+---
+
+## OTEL Collector Verification (Health + Export)
+
+### Required Checks
+
+- [ ] OTEL collector deployment is ready.
+- [ ] Collector logs show pipeline startup without fatal errors.
+- [ ] Exporter activity observed for configured backends (Prometheus remote write / Jaeger / ELK as applicable).
+
+### Evidence
+
+- Command output references:
+- Log excerpt references:
+- Notes:
+- **Status:** PASS / FAIL / PARTIAL
+
+---
+
+## Grafana Verification (Provisioning + Dashboards)
+
+### Required Checks
+
+- [ ] `neurologix-grafana-provisioning` ConfigMap present.
+- [ ] Datasources include `Prometheus` and `Jaeger`.
+- [ ] Dashboard provider `neurologix-observability` active.
+- [ ] Dashboards render: `control-plane`, `security-audit`, `mission-control-ui`.
+
+### Evidence
+
+- UI/API verification references:
+- Screenshot references:
+- Notes:
+- **Status:** PASS / FAIL / PARTIAL
+
+---
+
+## Rollback Trigger Review
+
+- Were rollback triggers reached (`control loop p99 > 200ms`, `error rate > 0.5%`, `audit write failure`, `safety bypass attempt`)? YES / NO
+- If YES, rollback action taken:
+- Related incident/runbook references:
+
+---
+
+## Outcome Summary
+
+- **Decision:** Keep rollout / Roll back / Partial rollback
+- **Follow-up Actions:**
+- **Owner + Due Date:**
+- **Approver / Reviewer:**

--- a/docs/runbooks/observability-staging-wiring.md
+++ b/docs/runbooks/observability-staging-wiring.md
@@ -75,6 +75,30 @@ Deployment baseline artifacts are in `infrastructure/observability/staging/`.
 
 ---
 
+## Rollout Evidence Capture (Required)
+
+For every staging rollout, create a filled evidence record using:
+
+- `docs/runbooks/observability-staging-rollout-evidence.md`
+
+Store execution-specific evidence under `planning/` and include:
+
+- command outputs for Prometheus rule load and active alerts,
+- OTEL collector health and exporter signals,
+- Grafana datasource/provider verification plus dashboard load checks,
+- operator, timestamp window, Git SHA/revision, and rollback trigger decisions.
+
+Recommended verification commands:
+
+```bash
+kubectl get configmap -n neurologix-observability neurologix-prometheus-alert-rules -o yaml
+kubectl logs -n neurologix-observability deploy/prometheus-server --tail=200 | grep -i "rule"
+kubectl logs -n neurologix-observability deploy/otel-collector --tail=200
+kubectl get pods -n neurologix-observability -l app.kubernetes.io/name=grafana
+```
+
+---
+
 ## Failure Handling
 
 - If Prometheus fails after values rollout, revert to prior release revision:

--- a/infrastructure/observability/staging/README.md
+++ b/infrastructure/observability/staging/README.md
@@ -52,6 +52,15 @@ Grafana checks:
 - Dashboard provider `neurologix-observability` is present.
 - Baseline dashboards render without query errors.
 
+## Evidence Capture
+
+For every staging rollout, complete:
+
+- `docs/runbooks/observability-staging-rollout-evidence.md`
+
+Store the filled record in `planning/` with timestamped artifact references
+(Prometheus logs, OTEL collector logs, Grafana verification outputs/screenshots).
+
 ## Notes
 
 - These files are deployment baselines only; environment-specific endpoints,

--- a/planning/issue-151-body.md
+++ b/planning/issue-151-body.md
@@ -1,0 +1,40 @@
+## Summary
+Phase 7 staging observability wiring artifacts exist, but rollout evidence capture is still ad hoc. We need a deterministic evidence scaffold that records whether staging actually loaded Prometheus alert rules, OTEL collector config/health, and Grafana provisioning/dashboards.
+
+## Why This Matters
+- IEC 62443 / ISO 27001 aligned operations require auditable deployment evidence.
+- Current runbook defines *how* to deploy but not a durable, repeatable evidence packet format.
+- Missing evidence weakens readiness for rollback validation, incident response, and compliance reviews.
+
+## Scope
+Create a docs/evidence scaffold for staging observability rollout verification:
+1. Evidence template/checklist for a single rollout execution.
+2. Structured fields for Prometheus, OTEL, and Grafana verification outcomes.
+3. Guidance on required artifacts (command outputs, screenshots, timestamps, operator).
+4. Update runbook index and developer TODO references.
+
+## Non-Goals
+- No runtime code changes.
+- No Kubernetes/Helm deployment changes.
+- No CI/CD workflow behavior changes.
+- No production rollout automation.
+
+## Acceptance Criteria
+- [ ] Add a new evidence template under `docs/runbooks/` (or adjacent docs path) for staging observability rollout verification.
+- [ ] Template includes sections for:
+  - [ ] Prometheus alert rule load verification
+  - [ ] OTEL collector health/export verification
+  - [ ] Grafana datasource/provisioning/dashboard verification
+- [ ] Template includes required metadata: environment, revision/SHA, timestamp window, owner/operator, pass/fail status, rollback trigger notes.
+- [ ] Existing staging wiring runbook references the new evidence template.
+- [ ] `docs/runbooks/README.md` and `.developer/TODO.md` are updated to reflect the new evidence capture path and status.
+- [ ] Local validation passes (`npm run lint`, `npm run type-check`).
+
+## Validation Evidence Expectations
+- Provide an example filled record file in `planning/` for this implementation cycle.
+- Include explicit checklist outcomes and any unresolved follow-ups.
+
+## Risks / Constraints
+- Keep diffs minimal and docs-focused.
+- Preserve existing terminology and runbook style.
+- Avoid introducing environment-specific secrets into evidence examples.

--- a/planning/staging-observability-evidence-issue-151.md
+++ b/planning/staging-observability-evidence-issue-151.md
@@ -1,0 +1,47 @@
+# Staging Observability Rollout Evidence — Issue #151 (Scaffold Validation)
+
+- **Environment:** staging (documentation scaffold validation)
+- **Date (UTC):** 2026-03-11
+- **Start Time (UTC):** 2026-03-11T00:00:00Z
+- **End Time (UTC):** 2026-03-11T00:30:00Z
+- **Operator / Owner:** auto-agent
+- **Issue / PR:** #151 / (pending PR)
+- **Git SHA / Revision:** docs branch `docs/issue-151-staging-observability-evidence`
+- **Overall Status:** PARTIAL
+
+## Scope of This Record
+
+This record validates the **evidence scaffold** introduced by Issue #151.
+No live staging rollout was executed in this change set; runtime outcomes are marked pending for next staged deployment window.
+
+## Prometheus Verification (Template Outcome)
+
+- [x] Verification section and required checks present in template.
+- [x] Evidence fields defined for command output and logs.
+- [ ] Live command outputs captured from staging cluster.
+- **Status:** PARTIAL
+
+## OTEL Verification (Template Outcome)
+
+- [x] Verification section and required checks present in template.
+- [x] Exporter signal capture field included.
+- [ ] Live collector health/export evidence captured.
+- **Status:** PARTIAL
+
+## Grafana Verification (Template Outcome)
+
+- [x] Verification section and required checks present in template.
+- [x] Datasource/provider/dashboard checks included.
+- [ ] Live UI/API validation evidence captured.
+- **Status:** PARTIAL
+
+## Rollback Trigger Review
+
+- Runtime rollback criteria were not evaluated in this docs-only scaffold slice.
+- Next rollout execution must complete this section with measured staging outcomes.
+
+## Follow-up Actions
+
+1. Execute staging rollout via `docs/runbooks/observability-staging-wiring.md`.
+2. Fill a new run record from `docs/runbooks/observability-staging-rollout-evidence.md`.
+3. Attach command outputs, logs, and dashboard screenshots under `planning/` with timestamped artifact names.


### PR DESCRIPTION
## Summary
Adds a minimal Phase 7 staging observability rollout evidence scaffold so each staging rollout has a durable, repeatable verification record.

## What changed
- Added rollout evidence template:
  - `docs/runbooks/observability-staging-rollout-evidence.md`
- Linked required evidence capture from:
  - `docs/runbooks/observability-staging-wiring.md`
  - `docs/runbooks/README.md`
  - `infrastructure/observability/staging/README.md`
- Updated `.developer/TODO.md` to mark scaffold completion and set next executable step.
- Added cycle example evidence record:
  - `planning/staging-observability-evidence-issue-151.md`

## Validation
- `npm run lint` (passes; existing warnings unchanged)
- `npm run type-check` (passes)

## Scope and risk
- Docs/planning only.
- No runtime behavior, deployment manifests, or CI workflow logic changes.

Closes #151
