### PR TITLE
Phase 7: add OPA policy bundle stubs with CI opa test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,25 @@ jobs:
         run: npm run test:contracts:consumers
 
   # ─────────────────────────
+  # OPA Policy Tests
+  # ─────────────────────────
+  opa-policy-tests:
+    name: OPA Policy Tests
+    runs-on: ubuntu-latest
+    needs: [model-state]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: latest
+
+      - name: Validate OPA policy bundle
+        run: npm run test:opa
+
+  # ─────────────────────────
   # Lighthouse CI (Mission Control UX SLO gate)
   # ─────────────────────────
   lighthouse-ci:
@@ -215,7 +234,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [model-state, lint, typecheck, test, contract-tests, lighthouse-ci]
+    needs: [model-state, lint, typecheck, test, contract-tests, opa-policy-tests, lighthouse-ci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/architecture/ADR-012-rbac-abac-authorization-design.md
+++ b/docs/architecture/ADR-012-rbac-abac-authorization-design.md
@@ -236,14 +236,14 @@ results in a deny-with-log rather than an inadvertent allow.
 
 ## Implementation Checklist (Phase 7)
 
-- [ ] Implement `safety_guard.rego` with unit tests
-- [ ] Implement `zone_boundary.rego` with unit tests
-- [ ] Implement `role_permissions.rego` with `data/roles.json`
+- [x] Implement `safety_guard.rego` with unit tests
+- [x] Implement `zone_boundary.rego` with unit tests
+- [x] Implement `role_permissions.rego` with `data/roles.json`
 - [ ] Implement `command_risk.rego` with `data/command_risk_levels.json`
-- [ ] Implement `ai_agent.rego` with unit tests
+- [x] Implement `ai_agent.rego` with unit tests
 - [ ] Wire `authorizer.ts` into policy-engine service
 - [ ] Validate OPA decision log routing to ELK audit pipeline
-- [ ] Add CI gate: `opa test packages/security-core/src/policies/`
+- [x] Add CI gate: `opa test packages/security-core/src/policies/`
 - [ ] Penetration test: verify AI agent cannot issue `critical` commands
 
 ## References

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:ci": "turbo run test:ci --force",
     "test:contracts:servers": "npm run test:contracts --workspace @neurologix/site-registry && npm run test:contracts --workspace @neurologix/capability-registry && npm run test:contracts --workspace @neurologix/policy-engine && npm run test:contracts --workspace @neurologix/recipe-executor && npm run test:contracts --workspace @neurologix/digital-twin && npm run test:contracts --workspace @neurologix/mission-control",
     "test:contracts:consumers": "npm run test:contracts:consumer --workspace @neurologix/mission-control && npm run test:contracts --workspace @neurologix/adapters",
+    "test:opa": "npm run test:opa --workspace @neurologix/security-core",
     "test:e2e": "turbo run test:e2e",
     "type-check": "turbo run type-check",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/packages/security-core/package.json
+++ b/packages/security-core/package.json
@@ -12,7 +12,8 @@
     "build": "tsc --build",
     "lint": "eslint src --ext .ts",
     "test": "vitest --config vitest.config.ts",
-    "test:ci": "vitest run --coverage --config vitest.config.ts"
+    "test:ci": "vitest run --coverage --config vitest.config.ts",
+    "test:opa": "opa test src/policies --format pretty"
   },
   "dependencies": {
     "crypto": "^1.0.1"

--- a/packages/security-core/src/policies/ai_agent.rego
+++ b/packages/security-core/src/policies/ai_agent.rego
@@ -1,0 +1,30 @@
+package neurologix.authz
+
+ai_identity_valid if {
+  data.data.neurologix.ai_identities[_] == input.caller_identity
+}
+
+ai_agent_constraints_satisfied if {
+  input.role != "ai_agent"
+}
+
+ai_agent_constraints_satisfied if {
+  input.role == "ai_agent"
+  input.from_zone == "ai"
+  input.operation == "dispatch_inference"
+  input.recipe_validated == true
+  input.command_risk_level != "critical"
+  ai_identity_valid
+}
+
+deny_reasons["ai_agent constraints violated"] if {
+  input.role == "ai_agent"
+  not ai_agent_constraints_satisfied
+}
+
+allow if {
+  not safety_interlock_blocked
+  zone_transition_allowed
+  allowed_by_role
+  ai_agent_constraints_satisfied
+}

--- a/packages/security-core/src/policies/data/roles.json
+++ b/packages/security-core/src/policies/data/roles.json
@@ -1,0 +1,49 @@
+{
+  "neurologix": {
+    "roles": {
+      "operator": [
+        "acknowledge_alarm",
+        "execute_recipe",
+        "read_site",
+        "read_recipe",
+        "read_audit"
+      ],
+      "supervisor": [
+        "acknowledge_alarm",
+        "execute_recipe",
+        "approve_command",
+        "manage_recipe_library",
+        "read_site",
+        "read_recipe",
+        "read_audit"
+      ],
+      "admin": [
+        "acknowledge_alarm",
+        "execute_recipe",
+        "approve_command",
+        "manage_recipe_library",
+        "manage_users",
+        "update_site_config",
+        "update_feature_flag",
+        "read_site",
+        "read_recipe",
+        "read_audit"
+      ],
+      "auditor": [
+        "read_site",
+        "read_recipe",
+        "read_policy",
+        "read_audit"
+      ],
+      "ai_agent": [
+        "dispatch_inference"
+      ],
+      "system": [
+        "service_call"
+      ]
+    },
+    "ai_identities": [
+      "ai-agent.neurologix-ai.svc.cluster.local"
+    ]
+  }
+}

--- a/packages/security-core/src/policies/role_permissions.rego
+++ b/packages/security-core/src/policies/role_permissions.rego
@@ -1,0 +1,12 @@
+package neurologix.authz
+
+allowed_by_role if {
+  role := input.role
+  operation := input.operation
+  role_permissions := data.data.neurologix.roles[role]
+  role_permissions[_] == operation
+}
+
+deny_reasons[sprintf("role '%s' is not allowed to perform '%s'", [input.role, input.operation])] if {
+  not allowed_by_role
+}

--- a/packages/security-core/src/policies/safety_guard.rego
+++ b/packages/security-core/src/policies/safety_guard.rego
@@ -1,0 +1,12 @@
+package neurologix.authz
+
+default allow := false
+
+safety_interlock_blocked if {
+  input.safety_interlock_active == true
+  input.operation != "acknowledge_alarm"
+}
+
+deny_reasons["safety interlock active: only acknowledge_alarm permitted"] if {
+  safety_interlock_blocked
+}

--- a/packages/security-core/src/policies/tests/authz_test.rego
+++ b/packages/security-core/src/policies/tests/authz_test.rego
@@ -1,0 +1,123 @@
+package neurologix.authz
+
+base_input := {
+  "role": "operator",
+  "operation": "execute_recipe",
+  "from_zone": "ui",
+  "to_zone": "core",
+  "safety_interlock_active": false,
+  "recipe_validated": true,
+  "command_risk_level": "low",
+  "caller_identity": "operator.user"
+}
+
+test_safety_interlock_blocks_non_acknowledge_alarm if {
+  not allow
+    with input as base_input
+    with input.safety_interlock_active as true
+    with input.operation as "execute_recipe"
+}
+
+test_safety_interlock_allows_acknowledge_alarm if {
+  allow
+    with input as base_input
+    with input.safety_interlock_active as true
+    with input.operation as "acknowledge_alarm"
+}
+
+test_zone_boundary_denies_ai_to_edge if {
+  not allow
+    with input as base_input
+    with input.role as "admin"
+    with input.operation as "update_site_config"
+    with input.from_zone as "ai"
+    with input.to_zone as "edge"
+}
+
+test_zone_boundary_denies_ui_to_edge if {
+  not allow
+    with input as base_input
+    with input.role as "admin"
+    with input.operation as "update_site_config"
+    with input.from_zone as "ui"
+    with input.to_zone as "edge"
+}
+
+test_zone_boundary_allows_ui_to_core if {
+  allow
+    with input as base_input
+    with input.role as "admin"
+    with input.operation as "update_site_config"
+    with input.from_zone as "ui"
+    with input.to_zone as "core"
+}
+
+test_role_permissions_allow_operator_execute_recipe if {
+  allow with input as base_input
+}
+
+test_role_permissions_deny_operator_manage_users if {
+  not allow
+    with input as base_input
+    with input.operation as "manage_users"
+}
+
+test_ai_agent_allow_valid_dispatch if {
+  allow
+    with input as base_input
+    with input.role as "ai_agent"
+    with input.operation as "dispatch_inference"
+    with input.from_zone as "ai"
+    with input.to_zone as "core"
+    with input.caller_identity as "ai-agent.neurologix-ai.svc.cluster.local"
+    with input.recipe_validated as true
+    with input.command_risk_level as "high"
+}
+
+test_ai_agent_deny_critical_risk if {
+  not allow
+    with input as base_input
+    with input.role as "ai_agent"
+    with input.operation as "dispatch_inference"
+    with input.from_zone as "ai"
+    with input.to_zone as "core"
+    with input.caller_identity as "ai-agent.neurologix-ai.svc.cluster.local"
+    with input.recipe_validated as true
+    with input.command_risk_level as "critical"
+}
+
+test_ai_agent_deny_unvalidated_recipe if {
+  not allow
+    with input as base_input
+    with input.role as "ai_agent"
+    with input.operation as "dispatch_inference"
+    with input.from_zone as "ai"
+    with input.to_zone as "core"
+    with input.caller_identity as "ai-agent.neurologix-ai.svc.cluster.local"
+    with input.recipe_validated as false
+    with input.command_risk_level as "high"
+}
+
+test_ai_agent_deny_non_ai_zone if {
+  not allow
+    with input as base_input
+    with input.role as "ai_agent"
+    with input.operation as "dispatch_inference"
+    with input.from_zone as "ui"
+    with input.to_zone as "core"
+    with input.caller_identity as "ai-agent.neurologix-ai.svc.cluster.local"
+    with input.recipe_validated as true
+    with input.command_risk_level as "high"
+}
+
+test_ai_agent_deny_invalid_identity if {
+  not allow
+    with input as base_input
+    with input.role as "ai_agent"
+    with input.operation as "dispatch_inference"
+    with input.from_zone as "ai"
+    with input.to_zone as "core"
+    with input.caller_identity as "untrusted-agent.neurologix-ai.svc.cluster.local"
+    with input.recipe_validated as true
+    with input.command_risk_level as "high"
+}

--- a/packages/security-core/src/policies/zone_boundary.rego
+++ b/packages/security-core/src/policies/zone_boundary.rego
@@ -1,0 +1,26 @@
+package neurologix.authz
+
+zone_transition_allowed if {
+  input.from_zone == "ai"
+  input.to_zone == "core"
+  input.operation == "dispatch_inference"
+}
+
+zone_transition_allowed if {
+  input.from_zone == "ui"
+  input.to_zone == "core"
+}
+
+zone_transition_allowed if {
+  input.from_zone == "edge"
+  input.to_zone == "core"
+}
+
+zone_transition_allowed if {
+  input.from_zone == "core"
+  input.to_zone == "edge"
+}
+
+deny_reasons["zone boundary violation"] if {
+  not zone_transition_allowed
+}


### PR DESCRIPTION
## Summary
- add ADR-012 OPA policy bundle stubs in @neurologix/security-core:
  - safety_guard.rego
  - zone_boundary.rego
  - ole_permissions.rego
  - i_agent.rego
- add role/identity policy data and OPA unit tests (PASS: 12/12)
- add workspace and package scripts for deterministic policy test execution (
pm run test:opa)
- add dedicated CI gate job opa-policy-tests in .github/workflows/ci.yml
- update ADR-012 implementation checklist entries completed by this slice

## Problem Solved
Issue #158 closes the Phase 7 design-to-code gap for core RBAC/ABAC policy stubs and establishes an explicit CI gate for policy correctness.

## Validation
- opa test packages/security-core/src/policies --format pretty ✅ (12/12)
- 
pm run test:opa --workspace @neurologix/security-core ✅
- 
pm run lint ✅
- 
pm run type-check ✅
- 
pm run test:ci ✅

## Risks / Follow-ups
- command_risk.rego and uditor.rego remain future slices.
- Runtime authorizer wiring into services remains future integration work.

Closes #158