### PR TITLE
feat(security-core): complete ADR-012 command-risk and auditor OPA policies (#160)

### DIFF
--- a/docs/architecture/ADR-012-rbac-abac-authorization-design.md
+++ b/docs/architecture/ADR-012-rbac-abac-authorization-design.md
@@ -239,8 +239,9 @@ results in a deny-with-log rather than an inadvertent allow.
 - [x] Implement `safety_guard.rego` with unit tests
 - [x] Implement `zone_boundary.rego` with unit tests
 - [x] Implement `role_permissions.rego` with `data/roles.json`
-- [ ] Implement `command_risk.rego` with `data/command_risk_levels.json`
+- [x] Implement `command_risk.rego` with `data/command_risk_levels.json`
 - [x] Implement `ai_agent.rego` with unit tests
+- [x] Implement `auditor.rego` read-only enforcement policy
 - [ ] Wire `authorizer.ts` into policy-engine service
 - [ ] Validate OPA decision log routing to ELK audit pipeline
 - [x] Add CI gate: `opa test packages/security-core/src/policies/`

--- a/packages/security-core/src/policies/ai_agent.rego
+++ b/packages/security-core/src/policies/ai_agent.rego
@@ -26,5 +26,7 @@ allow if {
   not safety_interlock_blocked
   zone_transition_allowed
   allowed_by_role
+  command_risk_constraints_satisfied
+  auditor_read_only_constraints_satisfied
   ai_agent_constraints_satisfied
 }

--- a/packages/security-core/src/policies/auditor.rego
+++ b/packages/security-core/src/policies/auditor.rego
@@ -1,0 +1,22 @@
+package neurologix.authz
+
+auditor_read_only_constraints_satisfied if {
+  input.role != "auditor"
+}
+
+auditor_read_only_constraints_satisfied if {
+  input.role == "auditor"
+  startswith(input.operation, "read_")
+  not input.http_method
+}
+
+auditor_read_only_constraints_satisfied if {
+  input.role == "auditor"
+  startswith(input.operation, "read_")
+  input.http_method == "GET"
+}
+
+deny_reasons["auditor role is read-only"] if {
+  input.role == "auditor"
+  not auditor_read_only_constraints_satisfied
+}

--- a/packages/security-core/src/policies/command_risk.rego
+++ b/packages/security-core/src/policies/command_risk.rego
@@ -1,0 +1,63 @@
+package neurologix.authz
+
+command_risk_policy_applies if {
+  data.data.neurologix.command_risk_levels[input.operation]
+}
+
+command_risk_level_matches_policy if {
+  expected_level := data.data.neurologix.command_risk_levels[input.operation]
+  input.command_risk_level == expected_level
+}
+
+risk_requirements_satisfied if {
+  input.command_risk_level == "low"
+  input.role == "operator"
+  input.confirmation_accepted == true
+}
+
+risk_requirements_satisfied if {
+  input.command_risk_level == "medium"
+  input.role == "operator"
+  input.confirmation_accepted == true
+}
+
+risk_requirements_satisfied if {
+  input.command_risk_level == "medium"
+  input.role == "supervisor"
+}
+
+risk_requirements_satisfied if {
+  input.command_risk_level == "high"
+  input.role == "supervisor"
+  input.confirmation_accepted == true
+  input.approvedByRole == "supervisor"
+}
+
+risk_requirements_satisfied if {
+  input.command_risk_level == "critical"
+  input.role == "admin"
+  input.confirmation_accepted == true
+  input.approvedByRole == "admin"
+  input.recipe_validated == true
+}
+
+command_risk_constraints_satisfied if {
+  not command_risk_policy_applies
+}
+
+command_risk_constraints_satisfied if {
+  command_risk_policy_applies
+  command_risk_level_matches_policy
+  risk_requirements_satisfied
+}
+
+deny_reasons[sprintf("command risk level mismatch for operation '%s'", [input.operation])] if {
+  command_risk_policy_applies
+  not command_risk_level_matches_policy
+}
+
+deny_reasons[sprintf("command risk constraints violated for level '%s'", [input.command_risk_level])] if {
+  command_risk_policy_applies
+  command_risk_level_matches_policy
+  not risk_requirements_satisfied
+}

--- a/packages/security-core/src/policies/data/command_risk_levels.json
+++ b/packages/security-core/src/policies/data/command_risk_levels.json
@@ -1,0 +1,11 @@
+{
+  "neurologix": {
+    "command_risk_levels": {
+      "execute_recipe": "low",
+      "manage_recipe_library": "medium",
+      "approve_command": "high",
+      "update_site_config": "critical",
+      "update_feature_flag": "critical"
+    }
+  }
+}

--- a/packages/security-core/src/policies/tests/authz_test.rego
+++ b/packages/security-core/src/policies/tests/authz_test.rego
@@ -6,6 +6,8 @@ base_input := {
   "from_zone": "ui",
   "to_zone": "core",
   "safety_interlock_active": false,
+  "confirmation_accepted": true,
+  "approvedByRole": "operator",
   "recipe_validated": true,
   "command_risk_level": "low",
   "caller_identity": "operator.user"
@@ -29,7 +31,7 @@ test_zone_boundary_denies_ai_to_edge if {
   not allow
     with input as base_input
     with input.role as "admin"
-    with input.operation as "update_site_config"
+    with input.operation as "manage_users"
     with input.from_zone as "ai"
     with input.to_zone as "edge"
 }
@@ -38,7 +40,7 @@ test_zone_boundary_denies_ui_to_edge if {
   not allow
     with input as base_input
     with input.role as "admin"
-    with input.operation as "update_site_config"
+    with input.operation as "manage_users"
     with input.from_zone as "ui"
     with input.to_zone as "edge"
 }
@@ -47,7 +49,7 @@ test_zone_boundary_allows_ui_to_core if {
   allow
     with input as base_input
     with input.role as "admin"
-    with input.operation as "update_site_config"
+    with input.operation as "manage_users"
     with input.from_zone as "ui"
     with input.to_zone as "core"
 }
@@ -120,4 +122,95 @@ test_ai_agent_deny_invalid_identity if {
     with input.caller_identity as "untrusted-agent.neurologix-ai.svc.cluster.local"
     with input.recipe_validated as true
     with input.command_risk_level as "high"
+}
+
+test_command_risk_deny_low_without_confirmation if {
+  not allow
+    with input as base_input
+    with input.confirmation_accepted as false
+}
+
+test_command_risk_allow_medium_supervisor_without_confirmation if {
+  allow
+    with input as base_input
+    with input.role as "supervisor"
+    with input.operation as "manage_recipe_library"
+    with input.command_risk_level as "medium"
+    with input.confirmation_accepted as false
+}
+
+test_command_risk_allow_high_supervisor_with_approval if {
+  allow
+    with input as base_input
+    with input.role as "supervisor"
+    with input.operation as "approve_command"
+    with input.command_risk_level as "high"
+    with input.confirmation_accepted as true
+    with input.approvedByRole as "supervisor"
+}
+
+test_command_risk_deny_high_without_approval_role if {
+  not allow
+    with input as base_input
+    with input.role as "supervisor"
+    with input.operation as "approve_command"
+    with input.command_risk_level as "high"
+    with input.confirmation_accepted as true
+    with input.approvedByRole as "operator"
+}
+
+test_command_risk_allow_critical_admin_with_validated_recipe if {
+  allow
+    with input as base_input
+    with input.role as "admin"
+    with input.operation as "update_site_config"
+    with input.command_risk_level as "critical"
+    with input.confirmation_accepted as true
+    with input.approvedByRole as "admin"
+    with input.recipe_validated as true
+}
+
+test_command_risk_deny_critical_without_validated_recipe if {
+  not allow
+    with input as base_input
+    with input.role as "admin"
+    with input.operation as "update_site_config"
+    with input.command_risk_level as "critical"
+    with input.confirmation_accepted as true
+    with input.approvedByRole as "admin"
+    with input.recipe_validated as false
+}
+
+test_command_risk_deny_when_input_level_mismatches_policy if {
+  not allow
+    with input as base_input
+    with input.role as "supervisor"
+    with input.operation as "approve_command"
+    with input.command_risk_level as "medium"
+    with input.confirmation_accepted as true
+    with input.approvedByRole as "supervisor"
+}
+
+test_auditor_allow_read_operation_with_get if {
+  allow
+    with input as base_input
+    with input.role as "auditor"
+    with input.operation as "read_audit"
+    with input.http_method as "GET"
+}
+
+test_auditor_deny_read_operation_with_post if {
+  not allow
+    with input as base_input
+    with input.role as "auditor"
+    with input.operation as "read_audit"
+    with input.http_method as "POST"
+}
+
+test_auditor_deny_mutating_operation if {
+  not allow
+    with input as base_input
+    with input.role as "auditor"
+    with input.operation as "update_site_config"
+    with input.http_method as "GET"
 }


### PR DESCRIPTION
## Summary
- implement command_risk.rego with ADR-012 low/medium/high/critical escalation rules
- implement uditor.rego enforcing auditor read-only constraints
- add command_risk_levels.json command-to-risk mapping data
- wire new constraints into shared authz allow path and extend OPA policy tests
- update ADR-012 implementation checklist for completed policy modules

## Validation
- 
pm run test:opa --workspace @neurologix/security-core
- 
pm run lint
- 
pm run type-check
- 
pm run test:ci

Closes #160