### PR TITLE
feat(security): add FR-5 Kubernetes NetworkPolicy baseline

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -31,11 +31,12 @@
 - [x] ADR-011: mTLS and Zero-Trust Service Mesh (`docs/architecture/ADR-011-mtls-zero-trust-service-mesh.md`) (Phase 7)
 - [x] ADR-012: RBAC/ABAC Authorization Design (`docs/architecture/ADR-012-rbac-abac-authorization-design.md`) (Phase 7)
 - [x] OPA authorizer integration baseline wired into policy-engine (`packages/security-core/src/opa-authorizer.ts`, `services/policy-engine/src/services/policy-engine.service.ts`) (Phase 7)
+- [x] Kubernetes NetworkPolicy baseline pack for zone segmentation (`infrastructure/security/network-policies/`) (Phase 7)
 
 ## Active / Near Term
 
 - Provision live staging Kubernetes cluster and execute live `kubectl apply -k` + Helm upgrades to replace dry-run evidence record with live cluster artifacts (Phase 9 / multi-site federation)
-- Implement Phase 7 planned items from IEC 62443 control mapping: mTLS cert-manager/Vault PKI wiring, audit log hash-chaining, Kubernetes NetworkPolicy, session replay protection
+- Implement Phase 7 planned items from IEC 62443 control mapping: mTLS cert-manager/Vault PKI wiring, audit log hash-chaining, session replay protection, Istio AuthorizationPolicy allowlists
 
 ## Quality Targets
 

--- a/docs/compliance/IEC-62443-control-mapping.md
+++ b/docs/compliance/IEC-62443-control-mapping.md
@@ -86,7 +86,7 @@ the Core, AI, and UI zones, and **Security Level 1 (SL-1)** for the Edge zone.
 
 | Req ID | Requirement | SL-2 Condition | Status | Evidence |
 |---|---|---|---|---|
-| SR 5.1 | Network segmentation | Kubernetes namespace isolation + NetworkPolicy per zone | ✅ Designed | [ADR-003](./ADR-003-security-first-architecture.md) |
+| SR 5.1 | Network segmentation | Kubernetes namespace isolation + NetworkPolicy per zone | ✅ Implemented (IaC baseline) | [ADR-003](./ADR-003-security-first-architecture.md), `infrastructure/security/network-policies/` |
 | SR 5.2 | Zone boundary protection | Istio/Linkerd AuthorizationPolicy allowlists per zone pair | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md) |
 | SR 5.3 | Security function isolation | Safety-critical code in `service/recipe-executor`; AI services isolated in AI zone | ✅ Implemented | `services/recipe-executor/` |
 | SR 5.4 | Control system backup | Helm chart state in Git (GitOps); Vault unseal keys backed up | 🔄 Planned | `infrastructure/` |
@@ -145,7 +145,7 @@ are all Phase 7 implementation work items, not design gaps)
 | Implement append-only audit log with hash-chaining | FR-2, FR-3 | High |
 | Concurrent session limits in OPA | FR-2 | Medium |
 | Session replay protection (nonce) | FR-3 | Medium |
-| Kubernetes NetworkPolicy + Istio AuthorizationPolicy | FR-5 | High |
+| Istio AuthorizationPolicy allowlists per zone pair | FR-5 | High |
 | Kubernetes resource requests/limits | FR-7 | Medium |
 | Helm GitOps IaC completion | FR-5, FR-7 | Medium |
 | API gateway rate limiting | FR-7 | Medium |

--- a/infrastructure/security/network-policies/README.md
+++ b/infrastructure/security/network-policies/README.md
@@ -1,0 +1,27 @@
+# NetworkPolicy Baseline (Phase 7)
+
+This directory contains the Kubernetes `NetworkPolicy` baseline for IEC 62443
+FR-5 (Restricted Data Flow) zone segmentation.
+
+## Scope
+
+- Namespace-level default deny for NeuroLogix trust zones:
+  - `neurologix-core`
+  - `neurologix-ai`
+  - `neurologix-edge`
+  - `neurologix-ui`
+- Explicit baseline zone-to-zone allows aligned to ADR-011.
+- DNS egress exceptions for cluster name resolution.
+
+## Apply
+
+```bash
+kubectl apply -k infrastructure/security/network-policies
+```
+
+## Notes
+
+- This is a baseline policy pack and does not replace service-mesh
+  `AuthorizationPolicy` controls.
+- Live cluster rollout evidence must be captured separately in staging and
+  production runbooks.

--- a/infrastructure/security/network-policies/allow-ai-core-edge-ui-zone-flows.yaml
+++ b/infrastructure/security/network-policies/allow-ai-core-edge-ui-zone-flows.yaml
@@ -1,0 +1,74 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ai-ingress-from-core
+  namespace: neurologix-ai
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-core
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ai-egress-to-core
+  namespace: neurologix-ai
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-core
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-edge-ingress-from-core
+  namespace: neurologix-edge
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-core
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-edge-egress-to-core
+  namespace: neurologix-edge
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-core
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ui-egress-to-core
+  namespace: neurologix-ui
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-core

--- a/infrastructure/security/network-policies/allow-core-ingress-from-ui-ai-edge.yaml
+++ b/infrastructure/security/network-policies/allow-core-ingress-from-ui-ai-edge.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-core-ingress-from-ui-ai-edge
+  namespace: neurologix-core
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-ui
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-ai
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: neurologix-edge

--- a/infrastructure/security/network-policies/allow-dns-egress.yaml
+++ b/infrastructure/security/network-policies/allow-dns-egress.yaml
@@ -1,0 +1,79 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: neurologix-core
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: neurologix-ai
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: neurologix-edge
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: neurologix-ui
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/infrastructure/security/network-policies/kustomization.yaml
+++ b/infrastructure/security/network-policies/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace-default-deny.yaml
+  - allow-dns-egress.yaml
+  - allow-core-ingress-from-ui-ai-edge.yaml
+  - allow-ai-core-edge-ui-zone-flows.yaml

--- a/infrastructure/security/network-policies/namespace-default-deny.yaml
+++ b/infrastructure/security/network-policies/namespace-default-deny.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: neurologix-core
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: neurologix-ai
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: neurologix-edge
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: neurologix-ui
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress


### PR DESCRIPTION
## Summary
- adds Kubernetes NetworkPolicy baseline pack for NeuroLogix trust zones under `infrastructure/security/network-policies/`
- enforces default-deny posture with explicit zone flow allow rules and DNS egress exceptions
- updates IEC 62443 FR-5 mapping evidence and `.developer/TODO.md` status

## Linked Issue
Closes #172

## Validation
- `npm run lint` (pass)
- `npm run type-check` (pass)
- `npm run test:ci` (pass)
- `kubectl kustomize infrastructure/security/network-policies` (not run: `kubectl` not available in local environment)

## Risk / Rollback
- IaC baseline only; no live cluster rollout in this PR
- rollback by reverting this commit if policy baseline requires adjustment