### PR TITLE
test(e2e): deterministic mission-control dispatch baseline

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -20,6 +20,7 @@ recovery, and safe-mode procedures.
 | [site-registry-triage.md](./site-registry-triage.md) | Incident triage for provisioning, feature flags, and federation topology integrity | Active |
 | [safe-mode-activation.md](./safe-mode-activation.md) | Full platform safe-mode activation, service suspension sequence, hardware interlock verification, and controlled recovery | Active |
 | [plc-interlock-override-checklist.md](./plc-interlock-override-checklist.md) | Temporary PLC interlock override authorization, execution guardrails, abort criteria, and audit evidence checklist | Active |
+| [mission-control-e2e-validation.md](./mission-control-e2e-validation.md) | Deterministic Playwright baseline for critical Mission Control policy-gated dispatch journey and CI E2E gate behavior | Active |
 
 ## Related Guidance
 

--- a/docs/runbooks/mission-control-e2e-validation.md
+++ b/docs/runbooks/mission-control-e2e-validation.md
@@ -1,0 +1,55 @@
+# Mission Control Deterministic E2E Validation
+
+## Purpose
+
+Provide a deterministic Playwright baseline for a critical operator journey:
+policy-gated dispatch command flow in Mission Control.
+
+## Scope
+
+- Validates that dispatch policy decisions are enforced before command execution.
+- Validates deterministic allow-path dispatch (`allocate_pick`, `operator`, confirmation accepted).
+- Validates denial path when confirmation is not accepted.
+
+## Local Execution
+
+1. Install dependencies:
+
+   ```bash
+   npm ci
+   ```
+
+2. Run deterministic E2E baseline:
+
+   ```bash
+   npm run test:e2e
+   ```
+
+## CI Gate
+
+- Workflow: `.github/workflows/ci.yml`
+- Job: `E2E`
+- Trigger: pull requests and pushes to `main`
+- Build gate: final `Build` job depends on `E2E`
+
+## Expected Evidence
+
+- Playwright summary shows all mission-control specs passed.
+- No conditional skips in the critical dispatch allow-path test.
+- CI `E2E` job is green for the PR head SHA.
+
+## Failure Triage
+
+1. Check policy endpoint behavior:
+   - `GET /api/control-policy?commandType=allocate_pick&actorRole=operator&confirmationAccepted=true`
+   - Expected status: `allowed`
+2. Check dispatch endpoint behavior:
+   - `POST /api/dispatch`
+   - Expected response status: `200` and result status `dispatched`
+3. Re-run local gate:
+
+   ```bash
+   npm run test:e2e
+   ```
+
+4. If still failing, inspect mission-control policy logic in `apps/mission-control/src/state/mission-control-state.ts` and dispatch route wiring in `apps/mission-control/src/server.ts`.

--- a/e2e/mission-control/dispatch.spec.ts
+++ b/e2e/mission-control/dispatch.spec.ts
@@ -106,8 +106,8 @@ test.describe('Mission Control — Control Policy Gate', () => {
 });
 
 test.describe('Mission Control — Dispatch Command (INV-001)', () => {
-  test('INV-001: dispatch with allowed policy succeeds', async ({ request, baseURL }) => {
-    // First check policy
+  test('INV-001: dispatch with deterministic allowed policy succeeds', async ({ request, baseURL }) => {
+    // Deterministic path: allocate_pick does not require elevated approval.
     const policyParams = new URLSearchParams({
       commandType: 'allocate_pick',
       actorRole: 'operator',
@@ -116,11 +116,7 @@ test.describe('Mission Control — Dispatch Command (INV-001)', () => {
     const policyResponse = await request.get(`${baseURL}/api/control-policy?${policyParams}`);
     const policy = await policyResponse.json();
 
-    if (policy.status !== 'allowed') {
-      // If policy doesn't grant 'allowed' in this configuration, skip gracefully
-      test.skip(true, `Policy returned ${policy.status}; dispatch test requires 'allowed' policy`);
-      return;
-    }
+    expect(policy.status).toBe('allowed');
 
     const dispatchResponse = await request.post(`${baseURL}/api/dispatch`, {
       data: makeDispatchPayload({
@@ -130,11 +126,13 @@ test.describe('Mission Control — Dispatch Command (INV-001)', () => {
       }),
     });
 
-    // Dispatch with valid policy should succeed (200 range)
-    expect(dispatchResponse.status()).toBeLessThan(500);
+    // Dispatch with valid policy should succeed
+    expect(dispatchResponse.status()).toBe(200);
 
     const result = await dispatchResponse.json();
     expect(result).not.toBeNull();
+    expect(result).toHaveProperty('status');
+    expect(result.status).toBe('dispatched');
   });
 
   test('INV-001: dispatch without confirmation is rejected by policy gate', async ({


### PR DESCRIPTION
## Summary
- harden critical mission-control dispatch E2E by removing conditional skip from the allow-path test
- add deterministic dispatch assertions (`policy.status === allowed`, HTTP 200, result `status === dispatched`)
- add a focused runbook for local/CI deterministic E2E validation and link it in runbook index

## Problem Solved
Ensures the critical policy-gated dispatch journey produces deterministic Playwright signal and no longer masks regressions with conditional skip behavior.

## Validation
- npm run test:e2e (pass, 19/19)
- npm run lint (pass)
- npm run type-check (pass)

Closes #173