### PR TITLE
chore(security): add STRICT PeerAuthentication baseline to mesh pack (#189)

### DIFF
--- a/infrastructure/security/authorization-policies/README.md
+++ b/infrastructure/security/authorization-policies/README.md
@@ -1,25 +1,29 @@
 # Istio AuthorizationPolicy Baseline (Phase 7)
 
-This directory contains the Istio `AuthorizationPolicy` baseline for IEC 62443
-FR-5 / SR 5.2 (zone boundary protection) aligned to
+This directory contains the Istio `PeerAuthentication` and `AuthorizationPolicy`
+baseline for IEC 62443 FR-5 / SR 5.2 (zone boundary protection) and IEC 62443
+FR-1 / SR 1.2 / SR 3.1 (mTLS identity enforcement), aligned to
 [ADR-011](../../../docs/architecture/ADR-011-mtls-zero-trust-service-mesh.md).
 
 ## Scope
 
-- Namespace-scoped default deny for NeuroLogix trust zones:
-  - `neurologix-core`
-  - `neurologix-ai`
-  - `neurologix-edge`
-  - `neurologix-ui`
-- Explicit zone-pair allowlists for baseline permitted flows:
-  - `neurologix-ui` -> `neurologix-core`
-  - `neurologix-ai` -> `neurologix-core`
-  - `neurologix-edge` -> `neurologix-core`
-  - `neurologix-core` -> `neurologix-ai`
-  - `neurologix-core` -> `neurologix-edge`
-  - `istio-system` -> `neurologix-ui` (ingress gateway path)
+### PeerAuthentication (mTLS Enforcement Prereq)
 
-## Service Principals Covered
+`peer-authentication-strict.yaml` — STRICT mTLS enforced in all four trust zone
+namespaces (`neurologix-core`, `neurologix-ai`, `neurologix-edge`,
+`neurologix-ui`). Without STRICT mode, Istio cannot verify principal identity
+and the `AuthorizationPolicy` allowlists below cannot enforce caller identity.
+
+### AuthorizationPolicy
+
+- Namespace-scoped default deny for all NeuroLogix trust zones.
+- Explicit zone-pair allowlists for baseline permitted flows:
+  - `neurologix-ui` → `neurologix-core` (operator API calls, all HTTP verbs)
+  - `neurologix-ai` → `neurologix-core` (inference input reads, **GET only**)
+  - `neurologix-edge` → `neurologix-core` (sensor events, GET + POST)
+  - `neurologix-core` → `neurologix-ai` (inference requests, POST + GET)
+  - `neurologix-core` → `neurologix-edge` (command dispatch, POST + GET)
+  - `istio-system` → `neurologix-ui` (ingress gateway → UI entry point)
 
 Baseline principals are represented as SPIFFE identity patterns per namespace:
 
@@ -29,8 +33,8 @@ Baseline principals are represented as SPIFFE identity patterns per namespace:
 - `cluster.local/ns/neurologix-ui/sa/*`
 - `cluster.local/ns/istio-system/sa/*`
 
-This keeps the baseline merge-safe while establishing explicit allowlists.
-As namespace service accounts are finalized in deployment manifests, wildcard
+This keeps the baseline merge-safe while establishing explicit allowlists. As
+namespace service accounts are finalized in deployment manifests, wildcard
 patterns should be tightened to exact service-account principals.
 
 ## Apply
@@ -43,5 +47,5 @@ kubectl apply -k infrastructure/security/authorization-policies
 
 - This baseline complements, and does not replace, Kubernetes `NetworkPolicy`
   controls in `infrastructure/security/network-policies/`.
-- Live cluster rollout evidence is captured separately in staging and
-  production runbooks.
+- Live cluster rollout evidence is captured separately in staging and production
+  runbooks.

--- a/infrastructure/security/authorization-policies/kustomization.yaml
+++ b/infrastructure/security/authorization-policies/kustomization.yaml
@@ -1,8 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # mTLS enforcement prerequisite — STRICT PeerAuthentication for all zones
+  - peer-authentication-strict.yaml
+  # Default-deny baseline — all zones
   - deny-all-default.yaml
-  - allow-core-ingress-from-ui-ai-edge.yaml
-  - allow-ai-ingress-from-core.yaml
-  - allow-edge-ingress-from-core.yaml
+  # Zone-pair allowlists — per-pair with HTTP method restrictions
+  - allow-edge-to-core.yaml
+  - allow-ai-to-core.yaml
+  - allow-ui-to-core.yaml
+  - allow-core-to-ai.yaml
+  - allow-core-to-edge.yaml
+  # Ingress gateway → UI zone (external operator access path)
   - allow-ui-ingress-from-istio-ingress.yaml

--- a/infrastructure/security/authorization-policies/peer-authentication-strict.yaml
+++ b/infrastructure/security/authorization-policies/peer-authentication-strict.yaml
@@ -1,0 +1,76 @@
+# PeerAuthentication — STRICT mTLS for all NeuroLogix trust zones
+#
+# Aligned with ADR-011 (mTLS Zero-Trust Service Mesh), IEC 62443 SR 1.2
+# (software process identification) and SR 3.1 (communication integrity).
+#
+# Enforcement: ALL inbound connections to each zone namespace must present a
+# valid Istio mTLS client certificate. Plain-text connections are rejected at
+# the Envoy sidecar before reaching the workload.
+#
+# This resource is a prerequisite for the AuthorizationPolicy allowlists in
+# this directory: without STRICT PeerAuthentication, principal-based allow
+# policies cannot be enforced.
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-core
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: core
+    security.neurologix.io/sl: "sl-2"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-ai
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: ai
+    security.neurologix.io/sl: "sl-2"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-edge
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: edge
+    security.neurologix.io/sl: "sl-1"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-ui
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: ui
+    security.neurologix.io/sl: "sl-2"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT


### PR DESCRIPTION
## Summary
- add peer-authentication-strict.yaml with namespace-scoped STRICT mTLS baselines for 
eurologix-core, 
eurologix-ai, 
eurologix-edge, and 
eurologix-ui
- include the new manifest in infrastructure/security/authorization-policies/kustomization.yaml
- update infrastructure/security/authorization-policies/README.md scope to explicitly include STRICT PeerAuthentication baseline coverage

## Validation
- 
px prettier --check "infrastructure/security/authorization-policies/peer-authentication-strict.yaml" "infrastructure/security/authorization-policies/kustomization.yaml" "infrastructure/security/authorization-policies/README.md"
- 
pm run validate:doc-packets

Closes #189