### PR TITLE
fix(security): restore strict mTLS baseline evidence (#189)

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -4,44 +4,71 @@
 
 ### Completed
 
-- [x] Schema validation and broker topic governance (`@neurologix/schemas/broker`)
+- [x] Schema validation and broker topic governance
+      (`@neurologix/schemas/broker`)
 - [x] Broker ACL enforcement (`packages/schemas/src/broker/acl.ts`)
 - [x] Broker runtime validation script (`scripts/validate-broker-runtime.js`)
-- [x] Server contract baselines for all 5 services (site-registry, capability-registry, policy-engine, recipe-executor, digital-twin)
+- [x] Server contract baselines for all 5 services (site-registry,
+      capability-registry, policy-engine, recipe-executor, digital-twin)
 - [x] Consumer contract tests — mission-control (consumer + server API)
 - [x] Broker consumer contract tests — adapters package
-- [x] Federation API endpoints (SITE-005, FF-002, FF-003) — all 9 FEDERATION_API_CONTRACTS covered
+- [x] Federation API endpoints (SITE-005, FF-002, FF-003) — all 9
+      FEDERATION_API_CONTRACTS covered
 - [x] ADR-010 contract testing strategy documented
-- [x] Observability baseline stubs (Prometheus alert rules, OTEL collector config)
-- [x] Grafana dashboard baseline stubs (control-plane, security-audit, mission-control-ui)
+- [x] Observability baseline stubs (Prometheus alert rules, OTEL collector
+      config)
+- [x] Grafana dashboard baseline stubs (control-plane, security-audit,
+      mission-control-ui)
 - [x] Observability baseline runbook
 - [x] Release rollback runbook
-- [x] Service incident triage playbooks per service (capability-registry, policy-engine, recipe-executor, digital-twin, site-registry)
+- [x] Service incident triage playbooks per service (capability-registry,
+      policy-engine, recipe-executor, digital-twin, site-registry)
 - [x] CI contract-tests gate (mainline + release workflows)
 - [x] Vitest coverage thresholds enforced repo-wide
 - [x] ADR index and phase-0 gap-report reconciled
 - [x] Lighthouse CI gate for mission-control in mainline CI
 - [x] Safe-mode activation procedure runbook (Phase 7)
 - [x] PLC interlock override checklist runbook (Phase 7)
-- [x] Staging observability wiring artifact baseline (Prometheus alert integration values, OTEL collector deployment baseline, Grafana provisioning baseline)
-- [x] Staging observability rollout evidence scaffold (required verification template + runbook linkage)
-- [x] First staging observability rollout evidence capture — dry-run baseline record in `planning/obs-staging-rollout-evidence-2026-03-11-issue-153.md` (Phase 7)
+- [x] Staging observability wiring artifact baseline (Prometheus alert
+      integration values, OTEL collector deployment baseline, Grafana
+      provisioning baseline)
+- [x] Staging observability rollout evidence scaffold (required verification
+      template + runbook linkage)
+- [x] First staging observability rollout evidence capture — dry-run baseline
+      record in `planning/obs-staging-rollout-evidence-2026-03-11-issue-153.md`
+      (Phase 7)
 
-- [x] IEC 62443 control mapping baseline (`docs/compliance/IEC-62443-control-mapping.md`) — 46 controls across FR-1 to FR-7, 79% compliant (Phase 7)
-- [x] ADR-011: mTLS and Zero-Trust Service Mesh (`docs/architecture/ADR-011-mtls-zero-trust-service-mesh.md`) (Phase 7)
-- [x] ADR-012: RBAC/ABAC Authorization Design (`docs/architecture/ADR-012-rbac-abac-authorization-design.md`) (Phase 7)
-- [x] OPA authorizer integration baseline wired into policy-engine (`packages/security-core/src/opa-authorizer.ts`, `services/policy-engine/src/services/policy-engine.service.ts`) (Phase 7)
-- [x] Session replay protection baseline wired through `security-core` nonce/timestamp guard and `policy-engine` requestId/session nonce integration (Phase 7)
-- [x] Kubernetes NetworkPolicy baseline pack for zone segmentation (`infrastructure/security/network-policies/`) (Phase 7)
-- [x] Istio AuthorizationPolicy allowlist baseline pack with STRICT PeerAuthentication companion manifests (`infrastructure/security/authorization-policies/`) (Phase 7)
+- [x] IEC 62443 control mapping baseline
+      (`docs/compliance/IEC-62443-control-mapping.md`) — 46 controls across FR-1
+      to FR-7, 79% compliant (Phase 7)
+- [x] ADR-011: mTLS and Zero-Trust Service Mesh
+      (`docs/architecture/ADR-011-mtls-zero-trust-service-mesh.md`) (Phase 7)
+- [x] ADR-012: RBAC/ABAC Authorization Design
+      (`docs/architecture/ADR-012-rbac-abac-authorization-design.md`) (Phase 7)
+- [x] OPA authorizer integration baseline wired into policy-engine
+      (`packages/security-core/src/opa-authorizer.ts`,
+      `services/policy-engine/src/services/policy-engine.service.ts`) (Phase 7)
+- [x] Session replay protection baseline wired through `security-core`
+      nonce/timestamp guard and `policy-engine` requestId/session nonce
+      integration (Phase 7)
+- [x] Kubernetes NetworkPolicy baseline pack for zone segmentation
+      (`infrastructure/security/network-policies/`) (Phase 7)
+- [x] Istio AuthorizationPolicy allowlist baseline pack with STRICT
+      PeerAuthentication companion manifests
+      (`infrastructure/security/authorization-policies/`) (Phase 7)
 
 ## Active / Near Term
 
-- Provision live staging Kubernetes cluster and execute live `kubectl apply -k` + Helm upgrades to replace dry-run evidence record with live cluster artifacts (Phase 9 / multi-site federation)
-- Implement Phase 7 planned items from IEC 62443 control mapping: mTLS cert-manager/Vault PKI wiring, audit log hash-chaining
+- Provision live staging Kubernetes cluster and execute live
+  `kubectl apply -k` + Helm upgrades to replace dry-run evidence record with
+  live cluster artifacts (Phase 9 / multi-site federation)
+- Implement remaining Phase 7 planned items from IEC 62443 control mapping: mTLS
+  cert-manager/Vault PKI wiring, concurrent session limits, Kubernetes resource
+  requests/limits, Helm GitOps IaC completion, API gateway rate limiting
 
 ## Quality Targets
 
 - Keep CI green on `main`.
 - Preserve coverage thresholds and model-first validation gates.
-- Prometheus alert rules must remain aligned with OBS-001 (`observability_model.yaml`).
+- Prometheus alert rules must remain aligned with OBS-001
+  (`observability_model.yaml`).

--- a/docs/compliance/IEC-62443-control-mapping.md
+++ b/docs/compliance/IEC-62443-control-mapping.md
@@ -3,18 +3,18 @@
 ## Purpose
 
 This document maps IEC 62443-3-3 System Security Requirements (SSR) to the
-NeuroLogix implementation status and provides evidence references for
-compliance attestation. NeuroLogix targets **Security Level 2 (SL-2)** for
-the Core, AI, and UI zones, and **Security Level 1 (SL-1)** for the Edge zone.
+NeuroLogix implementation status and provides evidence references for compliance
+attestation. NeuroLogix targets **Security Level 2 (SL-2)** for the Core, AI,
+and UI zones, and **Security Level 1 (SL-1)** for the Edge zone.
 
 ## Security Level Target
 
-| Zone | Namespace | Target SL | Rationale |
-|---|---|---|---|
-| SL-1 Edge | `neurologix-edge` | SL-1 | PLC/sensor adapters; hardware interlocks provide primary safety |
-| SL-2 Core | `neurologix-core` | SL-2 | Recipe execution, policy engine, capability registry — T1 critical |
-| SL-3 AI | `neurologix-ai` | SL-2 | AI inference services; never actuates PLCs directly |
-| SL-4 UI | `neurologix-ui` | SL-2 | Mission Control UI; operator-facing, multi-site |
+| Zone      | Namespace         | Target SL | Rationale                                                          |
+| --------- | ----------------- | --------- | ------------------------------------------------------------------ |
+| SL-1 Edge | `neurologix-edge` | SL-1      | PLC/sensor adapters; hardware interlocks provide primary safety    |
+| SL-2 Core | `neurologix-core` | SL-2      | Recipe execution, policy engine, capability registry — T1 critical |
+| SL-3 AI   | `neurologix-ai`   | SL-2      | AI inference services; never actuates PLCs directly                |
+| SL-4 UI   | `neurologix-ui`   | SL-2      | Mission Control UI; operator-facing, multi-site                    |
 
 ---
 
@@ -25,128 +25,133 @@ the Core, AI, and UI zones, and **Security Level 1 (SL-1)** for the Edge zone.
 > _Identify and authenticate all users, software processes, and devices before
 > allowing them to access the IACS._
 
-| Req ID | Requirement | SL-2 Condition | Status | Evidence |
-|---|---|---|---|---|
-| SR 1.1 | Human user identification and authentication | RBAC with IdP (OIDC + JWT) | ✅ Designed (Phase 7 impl.) | [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
-| SR 1.2 | Software process and device identification | mTLS certificate identity per service | ✅ Designed (Phase 7 impl.) | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md), [mTLS and mesh policy runbook](../runbooks/mtls-mesh-policy-validation.md) |
-| SR 1.3 | Account management | Roles defined in OPA data files (roles.json) | ✅ Designed | [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
-| SR 1.4 | Identifier management | JWT subject + mTLS CN as identity tokens | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md), [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
-| SR 1.5 | Authenticator management | cert-manager automated rotation (30-day TTL) | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md) |
-| SR 1.6 | Wireless access management | N/A — no wireless control surfaces | N/A | — |
-| SR 1.7 | Strength of password-based authentication | Delegated to IdP (Azure AD / Okta MFA policy) | ✅ Designed | [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
+| Req ID | Requirement                                  | SL-2 Condition                                | Status                      | Evidence                                                                                                     |
+| ------ | -------------------------------------------- | --------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| SR 1.1 | Human user identification and authentication | RBAC with IdP (OIDC + JWT)                    | ✅ Designed (Phase 7 impl.) | [ADR-012](./ADR-012-rbac-abac-authorization-design.md)                                                       |
+| SR 1.2 | Software process and device identification   | mTLS certificate identity per service         | ✅ Designed (Phase 7 impl.) | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md)                                                         |
+| SR 1.3 | Account management                           | Roles defined in OPA data files (roles.json)  | ✅ Designed                 | [ADR-012](./ADR-012-rbac-abac-authorization-design.md)                                                       |
+| SR 1.4 | Identifier management                        | JWT subject + mTLS CN as identity tokens      | ✅ Designed                 | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md), [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
+| SR 1.5 | Authenticator management                     | cert-manager automated rotation (30-day TTL)  | ✅ Designed                 | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md)                                                         |
+| SR 1.6 | Wireless access management                   | N/A — no wireless control surfaces            | N/A                         | —                                                                                                            |
+| SR 1.7 | Strength of password-based authentication    | Delegated to IdP (Azure AD / Okta MFA policy) | ✅ Designed                 | [ADR-012](./ADR-012-rbac-abac-authorization-design.md)                                                       |
 
 ### FR-2: Use Control (UC)
 
 > _Enforce the assigned privileges of authenticated identities._
 
-| Req ID | Requirement | SL-2 Condition | Status | Evidence |
-|---|---|---|---|---|
-| SR 2.1 | Authorization enforcement | OPA RBAC/ABAC policy evaluation | ✅ Designed (Phase 7 impl.) | [ADR-012](./ADR-012-rbac-abac-authorization-design.md), [ADR-008](./ADR-008-policy-engine-opa.md) |
-| SR 2.2 | Wireless use control | N/A | N/A | — |
-| SR 2.3 | Use of portable and mobile devices | Operator mobile devices access UI zone only (SL-2) | ✅ Designed | [ADR-003](./ADR-003-security-first-architecture.md) |
-| SR 2.4 | Mobile code | No mobile code execution in control path | ✅ Compliant | — |
-| SR 2.5 | Session lock | IdP session timeout policy enforced at JWT TTL | ✅ Designed | [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
-| SR 2.6 | Remote session termination | JWT revocation via IdP; OPA validates on each request | ✅ Designed | [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
-| SR 2.7 | Concurrent session control | OPA policy may limit concurrent sessions per role (Phase 7) | 🔄 Planned | [ADR-012](./ADR-012-rbac-abac-authorization-design.md) |
-| SR 2.8 | Auditable events | All authz decisions + control actions logged | ✅ Designed | [ADR-012](./ADR-012-rbac-abac-authorization-design.md), [ADR-004](./ADR-004-observability-strategy.md) |
-| SR 2.9 | Audit storage capacity | ELK cluster with retention policy; Prometheus alert on storage | ✅ Implemented | `infrastructure/observability/prometheus-alerts.yml` |
-| SR 2.10 | Response to audit processing failures | Prometheus alert `audit_log_write_failure_total > 0` | ✅ Implemented | `infrastructure/observability/prometheus-alerts.yml` |
-| SR 2.11 | Timestamps | ISO-8601 UTC from OpenTelemetry trace context | ✅ Implemented | [ADR-004](./ADR-004-observability-strategy.md) |
-| SR 2.12 | Non-repudiation | Append-only audit log with hash-chaining (Phase 7 impl.) | 🔄 Planned | [ADR-003](./ADR-003-security-first-architecture.md) |
+| Req ID  | Requirement                           | SL-2 Condition                                                 | Status                      | Evidence                                                                                               |
+| ------- | ------------------------------------- | -------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------ |
+| SR 2.1  | Authorization enforcement             | OPA RBAC/ABAC policy evaluation                                | ✅ Designed (Phase 7 impl.) | [ADR-012](./ADR-012-rbac-abac-authorization-design.md), [ADR-008](./ADR-008-policy-engine-opa.md)      |
+| SR 2.2  | Wireless use control                  | N/A                                                            | N/A                         | —                                                                                                      |
+| SR 2.3  | Use of portable and mobile devices    | Operator mobile devices access UI zone only (SL-2)             | ✅ Designed                 | [ADR-003](./ADR-003-security-first-architecture.md)                                                    |
+| SR 2.4  | Mobile code                           | No mobile code execution in control path                       | ✅ Compliant                | —                                                                                                      |
+| SR 2.5  | Session lock                          | IdP session timeout policy enforced at JWT TTL                 | ✅ Designed                 | [ADR-012](./ADR-012-rbac-abac-authorization-design.md)                                                 |
+| SR 2.6  | Remote session termination            | JWT revocation via IdP; OPA validates on each request          | ✅ Designed                 | [ADR-012](./ADR-012-rbac-abac-authorization-design.md)                                                 |
+| SR 2.7  | Concurrent session control            | OPA policy may limit concurrent sessions per role (Phase 7)    | 🔄 Planned                  | [ADR-012](./ADR-012-rbac-abac-authorization-design.md)                                                 |
+| SR 2.8  | Auditable events                      | All authz decisions + control actions logged                   | ✅ Designed                 | [ADR-012](./ADR-012-rbac-abac-authorization-design.md), [ADR-004](./ADR-004-observability-strategy.md) |
+| SR 2.9  | Audit storage capacity                | ELK cluster with retention policy; Prometheus alert on storage | ✅ Implemented              | `infrastructure/observability/prometheus-alerts.yml`                                                   |
+| SR 2.10 | Response to audit processing failures | Prometheus alert `audit_log_write_failure_total > 0`           | ✅ Implemented              | `infrastructure/observability/prometheus-alerts.yml`                                                   |
+| SR 2.11 | Timestamps                            | ISO-8601 UTC from OpenTelemetry trace context                  | ✅ Implemented              | [ADR-004](./ADR-004-observability-strategy.md)                                                         |
+| SR 2.12 | Non-repudiation                       | Append-only audit log with hash-chaining (Phase 7 impl.)       | 🔄 Planned                  | [ADR-003](./ADR-003-security-first-architecture.md)                                                    |
 
 ### FR-3: System Integrity (SI)
 
-> _Ensure the integrity of the IACS in order to prevent unauthorised manipulation._
+> _Ensure the integrity of the IACS in order to prevent unauthorised
+> manipulation._
 
-| Req ID | Requirement | SL-2 Condition | Status | Evidence |
-|---|---|---|---|---|
-| SR 3.1 | Communication integrity | mTLS for all inter-service; TLS 1.3 at ingress | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md), [mTLS and mesh policy runbook](../runbooks/mtls-mesh-policy-validation.md) |
-| SR 3.2 | Malicious code protection | Container image scanning (Trivy/Grype) in CI | ✅ Implemented | `.github/workflows/ci.yml` |
-| SR 3.3 | Security functionality verification | OPA unit tests gate policy bundle in CI | ✅ Designed | [ADR-010](./ADR-010-contract-testing-strategy.md) |
-| SR 3.4 | Software and information integrity | SBOM (CycloneDX) generated per build; signed images (cosign) | ✅ Implemented | `.github/workflows/release.yml` |
-| SR 3.5 | Input validation | Zod schema validation on all API inputs | ✅ Implemented | `packages/schemas/` |
-| SR 3.6 | Deterministic output | Recipe executor produces deterministic output from validated recipes | ✅ Implemented | `services/recipe-executor/` |
-| SR 3.7 | Error handling | Typed error codes in all API responses; no raw stack traces | ✅ Implemented | `packages/schemas/src/common/errors.ts` |
-| SR 3.8 | Session integrity | JWT + mTLS session; replay protection baseline via deterministic nonce + timestamp guard in `security-core` / `policy-engine` | ✅ Implemented (baseline) | [ADR-012](./ADR-012-rbac-abac-authorization-design.md), `packages/security-core/src/replay-protection.ts`, `services/policy-engine/src/services/policy-engine.service.ts` |
-| SR 3.9 | Protection of audit information | Append-only ELK store; Prometheus alert on tampering | 🔄 Planned | [ADR-003](./ADR-003-security-first-architecture.md) |
+| Req ID | Requirement                         | SL-2 Condition                                                                                                                | Status                    | Evidence                                                                                                                                                                  |
+| ------ | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SR 3.1 | Communication integrity             | mTLS for all inter-service; TLS 1.3 at ingress                                                                                | ✅ Designed               | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md), [mTLS and mesh policy runbook](../runbooks/mtls-mesh-policy-validation.md)                                          |
+| SR 3.2 | Malicious code protection           | Container image scanning (Trivy/Grype) in CI                                                                                  | ✅ Implemented            | `.github/workflows/ci.yml`                                                                                                                                                |
+| SR 3.3 | Security functionality verification | OPA unit tests gate policy bundle in CI                                                                                       | ✅ Designed               | [ADR-010](./ADR-010-contract-testing-strategy.md)                                                                                                                         |
+| SR 3.4 | Software and information integrity  | SBOM (CycloneDX) generated per build; signed images (cosign)                                                                  | ✅ Implemented            | `.github/workflows/release.yml`                                                                                                                                           |
+| SR 3.5 | Input validation                    | Zod schema validation on all API inputs                                                                                       | ✅ Implemented            | `packages/schemas/`                                                                                                                                                       |
+| SR 3.6 | Deterministic output                | Recipe executor produces deterministic output from validated recipes                                                          | ✅ Implemented            | `services/recipe-executor/`                                                                                                                                               |
+| SR 3.7 | Error handling                      | Typed error codes in all API responses; no raw stack traces                                                                   | ✅ Implemented            | `packages/schemas/src/common/errors.ts`                                                                                                                                   |
+| SR 3.8 | Session integrity                   | JWT + mTLS session; replay protection baseline via deterministic nonce + timestamp guard in `security-core` / `policy-engine` | ✅ Implemented (baseline) | [ADR-012](./ADR-012-rbac-abac-authorization-design.md), `packages/security-core/src/replay-protection.ts`, `services/policy-engine/src/services/policy-engine.service.ts` |
+| SR 3.9 | Protection of audit information     | Append-only ELK store; Prometheus alert on tampering                                                                          | 🔄 Planned                | [ADR-003](./ADR-003-security-first-architecture.md)                                                                                                                       |
 
 ### FR-4: Data Confidentiality (DC)
 
-> _Ensure the confidentiality of information on communication channels and in data repositories._
+> _Ensure the confidentiality of information on communication channels and in
+> data repositories._
 
-| Req ID | Requirement | SL-2 Condition | Status | Evidence |
-|---|---|---|---|---|
-| SR 4.1 | Information confidentiality | mTLS encrypts all inter-service traffic; TLS 1.3 at ingress | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md) |
-| SR 4.2 | Information persistence | Kubernetes Secrets (encrypted at rest via etcd encryption); Vault for sensitive secrets | ✅ Designed | [ADR-003](./ADR-003-security-first-architecture.md) |
-| SR 4.3 | Use of cryptography | TLS 1.3; AES-256-GCM for secrets at rest; RSA-2048 / EC P-256 for certificates | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md) |
+| Req ID | Requirement                 | SL-2 Condition                                                                          | Status      | Evidence                                             |
+| ------ | --------------------------- | --------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| SR 4.1 | Information confidentiality | mTLS encrypts all inter-service traffic; TLS 1.3 at ingress                             | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md) |
+| SR 4.2 | Information persistence     | Kubernetes Secrets (encrypted at rest via etcd encryption); Vault for sensitive secrets | ✅ Designed | [ADR-003](./ADR-003-security-first-architecture.md)  |
+| SR 4.3 | Use of cryptography         | TLS 1.3; AES-256-GCM for secrets at rest; RSA-2048 / EC P-256 for certificates          | ✅ Designed | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md) |
 
 ### FR-5: Restricted Data Flow (RDF)
 
-> _Segment the IACS network using zones and conduits to limit the unnecessary flow of information._
+> _Segment the IACS network using zones and conduits to limit the unnecessary
+> flow of information._
 
-| Req ID | Requirement | SL-2 Condition | Status | Evidence |
-|---|---|---|---|---|
-| SR 5.1 | Network segmentation | Kubernetes namespace isolation + NetworkPolicy per zone | ✅ Implemented (IaC baseline) | [ADR-003](./ADR-003-security-first-architecture.md), `infrastructure/security/network-policies/` |
-| SR 5.2 | Zone boundary protection | Istio `AuthorizationPolicy` allowlists plus STRICT `PeerAuthentication` manifests per zone pair | ✅ Implemented (IaC baseline) | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md), `infrastructure/security/authorization-policies/`, [mTLS and mesh policy runbook](../runbooks/mtls-mesh-policy-validation.md) |
-| SR 5.3 | Security function isolation | Safety-critical code in `service/recipe-executor`; AI services isolated in AI zone | ✅ Implemented | `services/recipe-executor/` |
-| SR 5.4 | Control system backup | Helm chart state in Git (GitOps); Vault unseal keys backed up | 🔄 Planned | `infrastructure/` |
+| Req ID | Requirement                 | SL-2 Condition                                                                                  | Status                        | Evidence                                                                                                |
+| ------ | --------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
+| SR 5.1 | Network segmentation        | Kubernetes namespace isolation + NetworkPolicy per zone                                         | ✅ Implemented (IaC baseline) | [ADR-003](./ADR-003-security-first-architecture.md), `infrastructure/security/network-policies/`        |
+| SR 5.2 | Zone boundary protection    | Istio `AuthorizationPolicy` allowlists plus STRICT `PeerAuthentication` manifests per zone pair | ✅ Implemented (IaC baseline) | [ADR-011](./ADR-011-mtls-zero-trust-service-mesh.md), `infrastructure/security/authorization-policies/` |
+| SR 5.3 | Security function isolation | Safety-critical code in `service/recipe-executor`; AI services isolated in AI zone              | ✅ Implemented                | `services/recipe-executor/`                                                                             |
+| SR 5.4 | Control system backup       | Helm chart state in Git (GitOps); Vault unseal keys backed up                                   | 🔄 Planned                    | `infrastructure/`                                                                                       |
 
 ### FR-6: Timely Response to Events (TRE)
 
-> _Respond to security violations by notifying the proper authority, reporting evidence, and taking timely corrective action._
+> _Respond to security violations by notifying the proper authority, reporting
+> evidence, and taking timely corrective action._
 
-| Req ID | Requirement | SL-2 Condition | Status | Evidence |
-|---|---|---|---|---|
-| SR 6.1 | Audit log accessibility | ELK Kibana dashboard for audit log search | ✅ Designed | [ADR-004](./ADR-004-observability-strategy.md) |
-| SR 6.2 | Continuous monitoring | Prometheus + Grafana dashboards; PagerDuty alerts | ✅ Designed | `infrastructure/observability/prometheus-alerts.yml` |
-| SR 6.3 | Response to identified incidents | Service incident triage runbooks (all 5 services) | ✅ Implemented | `docs/runbooks/` |
+| Req ID | Requirement                      | SL-2 Condition                                    | Status         | Evidence                                             |
+| ------ | -------------------------------- | ------------------------------------------------- | -------------- | ---------------------------------------------------- |
+| SR 6.1 | Audit log accessibility          | ELK Kibana dashboard for audit log search         | ✅ Designed    | [ADR-004](./ADR-004-observability-strategy.md)       |
+| SR 6.2 | Continuous monitoring            | Prometheus + Grafana dashboards; PagerDuty alerts | ✅ Designed    | `infrastructure/observability/prometheus-alerts.yml` |
+| SR 6.3 | Response to identified incidents | Service incident triage runbooks (all 5 services) | ✅ Implemented | `docs/runbooks/`                                     |
 
 ### FR-7: Resource Availability (RA)
 
-> _Ensure the availability of the IACS against degradation or denial of service._
+> _Ensure the availability of the IACS against degradation or denial of
+> service._
 
-| Req ID | Requirement | SL-2 Condition | Status | Evidence |
-|---|---|---|---|---|
-| SR 7.1 | Denial of service protection | Rate limiting at API gateway; Kubernetes HPA | 🔄 Planned | — |
-| SR 7.2 | Resource management | Kubernetes resource requests/limits per workload | 🔄 Planned | `infrastructure/` |
-| SR 7.3 | Control system backup | Helm GitOps; stateless service design | 🔄 Planned | `infrastructure/` |
-| SR 7.4 | Emergency power | Out of scope (physical facility responsibility) | N/A | — |
-| SR 7.5 | Emergency communication | PagerDuty/OpsGenie alerting; runbooks | ✅ Designed | `docs/runbooks/` |
-| SR 7.6 | Network and security configuration settings | All config in Git (IaC); Terraform for cloud infra | 🔄 Planned | `infrastructure/` |
-| SR 7.7 | Least functionality | Minimal container images (distroless base); no unnecessary services | ✅ Designed | [ADR-003](./ADR-003-security-first-architecture.md) |
-| SR 7.8 | Control system component inventory | SBOM per build (CycloneDX) | ✅ Implemented | `.github/workflows/release.yml` |
+| Req ID | Requirement                                 | SL-2 Condition                                                      | Status         | Evidence                                            |
+| ------ | ------------------------------------------- | ------------------------------------------------------------------- | -------------- | --------------------------------------------------- |
+| SR 7.1 | Denial of service protection                | Rate limiting at API gateway; Kubernetes HPA                        | 🔄 Planned     | —                                                   |
+| SR 7.2 | Resource management                         | Kubernetes resource requests/limits per workload                    | 🔄 Planned     | `infrastructure/`                                   |
+| SR 7.3 | Control system backup                       | Helm GitOps; stateless service design                               | 🔄 Planned     | `infrastructure/`                                   |
+| SR 7.4 | Emergency power                             | Out of scope (physical facility responsibility)                     | N/A            | —                                                   |
+| SR 7.5 | Emergency communication                     | PagerDuty/OpsGenie alerting; runbooks                               | ✅ Designed    | `docs/runbooks/`                                    |
+| SR 7.6 | Network and security configuration settings | All config in Git (IaC); Terraform for cloud infra                  | 🔄 Planned     | `infrastructure/`                                   |
+| SR 7.7 | Least functionality                         | Minimal container images (distroless base); no unnecessary services | ✅ Designed    | [ADR-003](./ADR-003-security-first-architecture.md) |
+| SR 7.8 | Control system component inventory          | SBOM per build (CycloneDX)                                          | ✅ Implemented | `.github/workflows/release.yml`                     |
 
 ---
 
 ## Summary Dashboard
 
-| FR | Compliant (✅) | Planned (🔄) | N/A | Total |
-|---|---|---|---|---|
-| FR-1 IAC | 6 | 0 | 1 | 7 |
-| FR-2 UC | 9 | 2 | 1 | 12 |
-| FR-3 SI | 8 | 1 | 0 | 9 |
-| FR-4 DC | 3 | 0 | 0 | 3 |
-| FR-5 RDF | 4 | 0 | 0 | 4 |
-| FR-6 TRE | 3 | 0 | 0 | 3 |
-| FR-7 RA | 2 | 4 | 2 | 8 |
-| **Total** | **35** | **7** | **4** | **46** |
+| FR        | Compliant (✅) | Planned (🔄) | N/A   | Total  |
+| --------- | -------------- | ------------ | ----- | ------ |
+| FR-1 IAC  | 6              | 0            | 1     | 7      |
+| FR-2 UC   | 9              | 2            | 1     | 12     |
+| FR-3 SI   | 8              | 1            | 0     | 9      |
+| FR-4 DC   | 3              | 0            | 0     | 3      |
+| FR-5 RDF  | 4              | 0            | 0     | 4      |
+| FR-6 TRE  | 3              | 0            | 0     | 3      |
+| FR-7 RA   | 2              | 4            | 2     | 8      |
+| **Total** | **35**         | **7**        | **4** | **46** |
 
-**Compliance rate (designed + implemented):** 35/42 = **83%** (planned items
-are all Phase 7 implementation work items, not design gaps)
+**Compliance rate (designed + implemented):** 35/42 = **83%** (planned items are
+all Phase 7 implementation work items, not design gaps)
 
 ---
 
 ## Planned / Open Items (Phase 7)
 
-| Item | FR | Priority |
-|---|---|---|
-| Implement mTLS + cert-manager + Vault PKI in staging | FR-1, FR-3, FR-4 | High |
-| Wire OPA authorizer into all services | FR-2 | High |
-| Implement append-only audit log with hash-chaining | FR-2, FR-3 | High |
-| Concurrent session limits in OPA | FR-2 | Medium |
-| Kubernetes resource requests/limits | FR-7 | Medium |
-| Helm GitOps IaC completion | FR-5, FR-7 | Medium |
-| API gateway rate limiting | FR-7 | Medium |
+| Item                                                 | FR               | Priority |
+| ---------------------------------------------------- | ---------------- | -------- |
+| Implement mTLS + cert-manager + Vault PKI in staging | FR-1, FR-3, FR-4 | High     |
+| Wire OPA authorizer into all services                | FR-2             | High     |
+| Implement append-only audit log with hash-chaining   | FR-2, FR-3       | High     |
+| Concurrent session limits in OPA                     | FR-2             | Medium   |
+| Kubernetes resource requests/limits                  | FR-7             | Medium   |
+| Helm GitOps IaC completion                           | FR-5, FR-7       | Medium   |
+| API gateway rate limiting                            | FR-7             | Medium   |
 
 ---
 

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -9,12 +9,12 @@ NeuroLogix controls, policies, and evidence tracking.
 
 **Phase 7 — Active** · IEC 62443 control mapping baseline established.
 
-| Document | Status | Last Updated |
-|---|---|---|
-| [IEC 62443 Control Mapping](./IEC-62443-control-mapping.md) | ✅ Baseline + FR-5 allowlist/mTLS evidence | 2026-03-11 |
-| ISO 27001 / NIST CSF Alignment Matrix | 🔄 Planned (Phase 7) | — |
-| Audit Evidence Register | 🔄 Planned (Phase 7) | — |
-| Penetration Test Report | 🔄 Planned (Phase 7) | — |
+| Document                                                    | Status                                     | Last Updated |
+| ----------------------------------------------------------- | ------------------------------------------ | ------------ |
+| [IEC 62443 Control Mapping](./IEC-62443-control-mapping.md) | ✅ Baseline + FR-5 allowlist/mTLS evidence | 2026-03-11   |
+| ISO 27001 / NIST CSF Alignment Matrix                       | 🔄 Planned (Phase 7)                       | —            |
+| Audit Evidence Register                                     | 🔄 Planned (Phase 7)                       | —            |
+| Penetration Test Report                                     | 🔄 Planned (Phase 7)                       | —            |
 
 ## IEC 62443 Compliance Summary
 
@@ -22,11 +22,12 @@ NeuroLogix targets **Security Level 2 (SL-2)** for Core, AI, and UI zones, and
 **SL-1** for the Edge zone.
 
 - **Controls mapped:** 46 across FR-1 through FR-7
-- **Compliant (designed + implemented):** 33/42 = 79%
-- **Planned (Phase 7 implementation work):** 9
+- **Compliant (designed + implemented):** 35/42 = 83%
+- **Planned (Phase 7 implementation work):** 7
 - **Not Applicable:** 4
 
-See [IEC-62443-control-mapping.md](./IEC-62443-control-mapping.md) for full detail.
+See [IEC-62443-control-mapping.md](./IEC-62443-control-mapping.md) for full
+detail.
 
 ## Architecture Evidence
 
@@ -35,9 +36,10 @@ See [IEC-62443-control-mapping.md](./IEC-62443-control-mapping.md) for full deta
 - [ADR-011: mTLS and Zero-Trust Service Mesh](../architecture/ADR-011-mtls-zero-trust-service-mesh.md)
 - [ADR-012: RBAC/ABAC Authorization Design](../architecture/ADR-012-rbac-abac-authorization-design.md)
 
-## Operational Evidence
+## Infrastructure Evidence
 
-- [mTLS and mesh policy operations runbook](../runbooks/mtls-mesh-policy-validation.md)
+- [Istio AuthorizationPolicy baseline pack](../../infrastructure/security/authorization-policies/README.md)
+- [Kubernetes NetworkPolicy baseline pack](../../infrastructure/security/network-policies/README.md)
 
 ## Related
 

--- a/infrastructure/security/authorization-policies/README.md
+++ b/infrastructure/security/authorization-policies/README.md
@@ -29,8 +29,8 @@ Baseline principals are represented as SPIFFE identity patterns per namespace:
 - `cluster.local/ns/neurologix-ui/sa/*`
 - `cluster.local/ns/istio-system/sa/*`
 
-This keeps the baseline merge-safe while establishing explicit allowlists.
-As namespace service accounts are finalized in deployment manifests, wildcard
+This keeps the baseline merge-safe while establishing explicit allowlists. As
+namespace service accounts are finalized in deployment manifests, wildcard
 patterns should be tightened to exact service-account principals.
 
 ## Apply
@@ -43,5 +43,5 @@ kubectl apply -k infrastructure/security/authorization-policies
 
 - This baseline complements, and does not replace, Kubernetes `NetworkPolicy`
   controls in `infrastructure/security/network-policies/`.
-- Live cluster rollout evidence is captured separately in staging and
-  production runbooks.
+- Live cluster rollout evidence is captured separately in staging and production
+  runbooks.

--- a/infrastructure/security/authorization-policies/kustomization.yaml
+++ b/infrastructure/security/authorization-policies/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # PeerAuthentication STRICT must be applied before AuthorizationPolicy
+  # to enable principal-based enforcement.
+  - peer-authentication-strict.yaml
   - deny-all-default.yaml
   - allow-core-ingress-from-ui-ai-edge.yaml
   - allow-ai-ingress-from-core.yaml

--- a/infrastructure/security/authorization-policies/peer-authentication-strict.yaml
+++ b/infrastructure/security/authorization-policies/peer-authentication-strict.yaml
@@ -1,0 +1,78 @@
+# PeerAuthentication — STRICT mTLS for all NeuroLogix trust zones
+#
+# Companion to the AuthorizationPolicy baseline in this directory.
+# STRICT mode is a prerequisite for principal-based AuthorizationPolicy
+# enforcement: without it, Istio cannot verify the caller identity embedded
+# in each AuthorizationPolicy rule's `principals` field.
+#
+# IEC 62443 Reference: SR 1.2 (Software Process Identification), SR 3.1
+# (Communication Integrity)
+# ADR Reference: ADR-011 (mTLS Zero-Trust Service Mesh)
+#
+# All inbound connections to each zone namespace must present a valid Istio
+# mTLS certificate. Plain-text (non-mTLS) connections are rejected at the
+# Envoy sidecar before reaching the workload.
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-core
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: core
+    security.neurologix.io/sl: "sl-2"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-ai
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: ai
+    security.neurologix.io/sl: "sl-2"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-edge
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: edge
+    security.neurologix.io/sl: "sl-1"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: neurologix-ui
+  labels:
+    app.kubernetes.io/part-of: neurologix
+    security.neurologix.io/zone: ui
+    security.neurologix.io/sl: "sl-2"
+  annotations:
+    security.neurologix.io/iec62443-sr: "SR 1.2, SR 3.1"
+    security.neurologix.io/adr: "ADR-011"
+spec:
+  mtls:
+    mode: STRICT


### PR DESCRIPTION
## Summary
- restore the missing `peer-authentication-strict.yaml` baseline so the authorization policy pack includes the STRICT mTLS prerequisite from ADR-011
- refresh the authorization policy pack documentation and compliance evidence to reference the strict mTLS companion manifests
- update Phase 7 developer/compliance tracking to keep IEC 62443 totals aligned with the restored baseline evidence

## Validation
- `npx prettier --check ".developer/TODO.md" "docs/compliance/IEC-62443-control-mapping.md" "docs/compliance/README.md" "infrastructure/security/authorization-policies/README.md" "infrastructure/security/authorization-policies/kustomization.yaml" "infrastructure/security/authorization-policies/peer-authentication-strict.yaml"`
- `npm run validate:doc-packets`
- `git diff --check`
- `kubectl kustomize infrastructure/security/authorization-policies` unavailable locally (`kubectl` not installed)

Closes #189