### PR TITLE
docs(compliance): add ISO 27001/NIST CSF baseline alignment matrix

### DIFF
--- a/.developer/TODO.md
+++ b/.developer/TODO.md
@@ -4,44 +4,72 @@
 
 ### Completed
 
-- [x] Schema validation and broker topic governance (`@neurologix/schemas/broker`)
+- [x] Schema validation and broker topic governance
+      (`@neurologix/schemas/broker`)
 - [x] Broker ACL enforcement (`packages/schemas/src/broker/acl.ts`)
 - [x] Broker runtime validation script (`scripts/validate-broker-runtime.js`)
-- [x] Server contract baselines for all 5 services (site-registry, capability-registry, policy-engine, recipe-executor, digital-twin)
+- [x] Server contract baselines for all 5 services (site-registry,
+      capability-registry, policy-engine, recipe-executor, digital-twin)
 - [x] Consumer contract tests — mission-control (consumer + server API)
 - [x] Broker consumer contract tests — adapters package
-- [x] Federation API endpoints (SITE-005, FF-002, FF-003) — all 9 FEDERATION_API_CONTRACTS covered
+- [x] Federation API endpoints (SITE-005, FF-002, FF-003) — all 9
+      FEDERATION_API_CONTRACTS covered
 - [x] ADR-010 contract testing strategy documented
-- [x] Observability baseline stubs (Prometheus alert rules, OTEL collector config)
-- [x] Grafana dashboard baseline stubs (control-plane, security-audit, mission-control-ui)
+- [x] Observability baseline stubs (Prometheus alert rules, OTEL collector
+      config)
+- [x] Grafana dashboard baseline stubs (control-plane, security-audit,
+      mission-control-ui)
 - [x] Observability baseline runbook
 - [x] Release rollback runbook
-- [x] Service incident triage playbooks per service (capability-registry, policy-engine, recipe-executor, digital-twin, site-registry)
+- [x] Service incident triage playbooks per service (capability-registry,
+      policy-engine, recipe-executor, digital-twin, site-registry)
 - [x] CI contract-tests gate (mainline + release workflows)
 - [x] Vitest coverage thresholds enforced repo-wide
 - [x] ADR index and phase-0 gap-report reconciled
 - [x] Lighthouse CI gate for mission-control in mainline CI
 - [x] Safe-mode activation procedure runbook (Phase 7)
 - [x] PLC interlock override checklist runbook (Phase 7)
-- [x] Staging observability wiring artifact baseline (Prometheus alert integration values, OTEL collector deployment baseline, Grafana provisioning baseline)
-- [x] Staging observability rollout evidence scaffold (required verification template + runbook linkage)
-- [x] First staging observability rollout evidence capture — dry-run baseline record in `planning/obs-staging-rollout-evidence-2026-03-11-issue-153.md` (Phase 7)
+- [x] Staging observability wiring artifact baseline (Prometheus alert
+      integration values, OTEL collector deployment baseline, Grafana
+      provisioning baseline)
+- [x] Staging observability rollout evidence scaffold (required verification
+      template + runbook linkage)
+- [x] First staging observability rollout evidence capture — dry-run baseline
+      record in `planning/obs-staging-rollout-evidence-2026-03-11-issue-153.md`
+      (Phase 7)
 
-- [x] IEC 62443 control mapping baseline (`docs/compliance/IEC-62443-control-mapping.md`) — 46 controls across FR-1 to FR-7, 79% compliant (Phase 7)
-- [x] ADR-011: mTLS and Zero-Trust Service Mesh (`docs/architecture/ADR-011-mtls-zero-trust-service-mesh.md`) (Phase 7)
-- [x] ADR-012: RBAC/ABAC Authorization Design (`docs/architecture/ADR-012-rbac-abac-authorization-design.md`) (Phase 7)
-- [x] OPA authorizer integration baseline wired into policy-engine (`packages/security-core/src/opa-authorizer.ts`, `services/policy-engine/src/services/policy-engine.service.ts`) (Phase 7)
-- [x] Session replay protection baseline wired through `security-core` nonce/timestamp guard and `policy-engine` requestId/session nonce integration (Phase 7)
-- [x] Kubernetes NetworkPolicy baseline pack for zone segmentation (`infrastructure/security/network-policies/`) (Phase 7)
-- [x] Istio AuthorizationPolicy allowlist baseline pack with STRICT PeerAuthentication companion manifests (`infrastructure/security/authorization-policies/`) (Phase 7)
+- [x] IEC 62443 control mapping baseline
+      (`docs/compliance/IEC-62443-control-mapping.md`) — 46 controls across FR-1
+      to FR-7, 79% compliant (Phase 7)
+- [x] ADR-011: mTLS and Zero-Trust Service Mesh
+      (`docs/architecture/ADR-011-mtls-zero-trust-service-mesh.md`) (Phase 7)
+- [x] ADR-012: RBAC/ABAC Authorization Design
+      (`docs/architecture/ADR-012-rbac-abac-authorization-design.md`) (Phase 7)
+- [x] ISO 27001 / NIST CSF baseline alignment matrix
+      (`docs/compliance/ISO27001-NIST-CSF-alignment-matrix.md`) (Phase 7)
+- [x] OPA authorizer integration baseline wired into policy-engine
+      (`packages/security-core/src/opa-authorizer.ts`,
+      `services/policy-engine/src/services/policy-engine.service.ts`) (Phase 7)
+- [x] Session replay protection baseline wired through `security-core`
+      nonce/timestamp guard and `policy-engine` requestId/session nonce
+      integration (Phase 7)
+- [x] Kubernetes NetworkPolicy baseline pack for zone segmentation
+      (`infrastructure/security/network-policies/`) (Phase 7)
+- [x] Istio AuthorizationPolicy allowlist baseline pack with STRICT
+      PeerAuthentication companion manifests
+      (`infrastructure/security/authorization-policies/`) (Phase 7)
 
 ## Active / Near Term
 
-- Provision live staging Kubernetes cluster and execute live `kubectl apply -k` + Helm upgrades to replace dry-run evidence record with live cluster artifacts (Phase 9 / multi-site federation)
-- Implement Phase 7 planned items from IEC 62443 control mapping: mTLS cert-manager/Vault PKI wiring, audit log hash-chaining
+- Provision live staging Kubernetes cluster and execute live
+  `kubectl apply -k` + Helm upgrades to replace dry-run evidence record with
+  live cluster artifacts (Phase 9 / multi-site federation)
+- Implement Phase 7 planned items from IEC 62443 control mapping: mTLS
+  cert-manager/Vault PKI wiring, audit log hash-chaining
 
 ## Quality Targets
 
 - Keep CI green on `main`.
 - Preserve coverage thresholds and model-first validation gates.
-- Prometheus alert rules must remain aligned with OBS-001 (`observability_model.yaml`).
+- Prometheus alert rules must remain aligned with OBS-001
+  (`observability_model.yaml`).

--- a/docs/compliance/ISO27001-NIST-CSF-alignment-matrix.md
+++ b/docs/compliance/ISO27001-NIST-CSF-alignment-matrix.md
@@ -1,0 +1,73 @@
+# ISO 27001 and NIST CSF Baseline Alignment Matrix
+
+## Purpose
+
+This document provides a baseline crosswalk between NeuroLogix Phase 7 security
+artifacts and:
+
+- **ISO/IEC 27001:2022 Annex A** control families
+- **NIST CSF 2.0** functions and categories
+
+It is designed as an evidence index for audits and internal readiness reviews,
+and complements the detailed control-level mapping in
+[IEC 62443 Control Mapping](./IEC-62443-control-mapping.md).
+
+## Scope and Method
+
+- Scope is limited to controls with existing evidence in repository artifacts.
+- Status terms align with current delivery state:
+  - **Implemented**: baseline artifact exists and is wired in code/IaC/CI
+  - **Designed**: architecture/control design documented, runtime completion
+    pending
+  - **Planned**: explicitly tracked in Phase 7/8 backlog
+- This baseline does not replace a formal Statement of Applicability (SoA).
+
+## Baseline Matrix
+
+| Domain                   | ISO/IEC 27001:2022 (Annex A)                                             | NIST CSF 2.0 | NeuroLogix Baseline Control                                        | Status                            | Evidence                                                                                                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------ | ------------ | ------------------------------------------------------------------ | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Governance               | A.5.1 Policies for information security                                  | GV.PO        | Security-first governance and model-first policy set               | Implemented (baseline)            | [Copilot Instructions](../../.github/copilot-instructions.md), [.developer/TODO](../../.developer/TODO.md)                                                                                                                                      |
+| Governance               | A.5.8 Information security in project management                         | GV.OV        | Security and compliance controls tracked per phase and issue       | Implemented (baseline)            | [.developer/TODO](../../.developer/TODO.md), [Compliance README](./README.md)                                                                                                                                                                   |
+| Organization             | A.5.2 Information security roles and responsibilities                    | GV.RR        | RBAC/ABAC role model and authorization boundaries                  | Designed                          | [ADR-012](../architecture/ADR-012-rbac-abac-authorization-design.md)                                                                                                                                                                            |
+| Identity and Access      | A.8.2 Privileged access rights                                           | PR.AA        | Least-privilege authorization enforced via OPA policy model        | Designed                          | [ADR-012](../architecture/ADR-012-rbac-abac-authorization-design.md), [ADR-008](../architecture/ADR-008-policy-engine-opa.md)                                                                                                                   |
+| Identity and Access      | A.8.5 Secure authentication                                              | PR.AA        | Service identity through mTLS and certificate-based trust          | Designed                          | [ADR-011](../architecture/ADR-011-mtls-zero-trust-service-mesh.md), [mTLS mesh runbook](../runbooks/mtls-mesh-policy-validation.md)                                                                                                             |
+| Network Security         | A.8.20 Network security                                                  | PR.PS        | Namespace segmentation + allowlist mesh policy baseline            | Implemented (IaC baseline)        | [IEC 62443 mapping FR-5](./IEC-62443-control-mapping.md), [Authorization policies baseline](../../infrastructure/security/authorization-policies/README.md), [NetworkPolicy baseline](../../infrastructure/security/network-policies/README.md) |
+| Network Security         | A.8.21 Security of network services                                      | PR.PS        | Trust-zone boundary policy for inter-service communication         | Implemented (IaC baseline)        | [ADR-011](../architecture/ADR-011-mtls-zero-trust-service-mesh.md), [Authorization policies baseline](../../infrastructure/security/authorization-policies/README.md)                                                                           |
+| Cryptography             | A.8.24 Use of cryptography                                               | PR.DS        | TLS 1.3 for ingress and mTLS in mesh design                        | Designed                          | [ADR-011](../architecture/ADR-011-mtls-zero-trust-service-mesh.md), [IEC 62443 mapping FR-4](./IEC-62443-control-mapping.md)                                                                                                                    |
+| Logging and Monitoring   | A.8.15 Logging                                                           | DE.CM        | Structured audit and observability signals with alerting baselines | Implemented (baseline)            | [ADR-004](../architecture/ADR-004-observability-strategy.md), [Prometheus alerts](../../infrastructure/observability/prometheus-alerts.yml)                                                                                                     |
+| Logging and Monitoring   | A.8.16 Monitoring activities                                             | DE.CM        | Continuous monitoring with Prometheus/Grafana + runbooks           | Designed / Implemented (baseline) | [Runbooks index](../runbooks/README.md), [Prometheus alerts](../../infrastructure/observability/prometheus-alerts.yml)                                                                                                                          |
+| Logging and Monitoring   | A.8.17 Clock synchronization                                             | DE.CM        | UTC timestamping via OpenTelemetry trace propagation               | Implemented                       | [IEC 62443 mapping SR 2.11](./IEC-62443-control-mapping.md), [ADR-004](../architecture/ADR-004-observability-strategy.md)                                                                                                                       |
+| System Integrity         | A.8.9 Configuration management                                           | PR.PS        | Infrastructure and security controls managed as code in repo       | Implemented (baseline)            | [NetworkPolicy baseline](../../infrastructure/security/network-policies/README.md), [Authorization policies baseline](../../infrastructure/security/authorization-policies/README.md)                                                           |
+| Vulnerability Management | A.8.8 Management of technical vulnerabilities                            | ID.RA        | CI vulnerability scanning and dependency governance baselines      | Implemented                       | [CI workflow](../../.github/workflows/ci.yml), [Release workflow](../../.github/workflows/release.yml)                                                                                                                                          |
+| Supply Chain Integrity   | A.8.7 Protection against malware / integrity tooling                     | PR.PS        | SBOM generation and image integrity controls in release path       | Implemented                       | [Release workflow](../../.github/workflows/release.yml)                                                                                                                                                                                         |
+| Incident Response        | A.5.24 Information security incident management planning and preparation | RS.RP        | Incident triage and security control runbooks                      | Implemented (baseline)            | [Runbooks index](../runbooks/README.md), [mTLS mesh runbook](../runbooks/mtls-mesh-policy-validation.md)                                                                                                                                        |
+| Incident Response        | A.5.26 Response to information security incidents                        | RS.AN        | Service-level incident procedures with evidence capture templates  | Implemented (baseline)            | [Runbooks index](../runbooks/README.md)                                                                                                                                                                                                         |
+| Resilience               | A.5.30 ICT readiness for business continuity                             | RC.RP        | Safe-mode and rollback procedures for mission-critical controls    | Implemented (baseline)            | [Safe mode activation](../runbooks/safe-mode-activation.md), [Release rollback](../runbooks/release-rollback.md)                                                                                                                                |
+
+## Coverage Snapshot (Baseline)
+
+- Governance and policy evidence: **baseline present**
+- Identity, access, and mTLS enforcement: **designed with partial runtime
+  completion**
+- Network segmentation and allowlist controls: **implemented baseline IaC pack**
+- Monitoring, logging, and incident response: **implemented baseline artifacts**
+- Remaining gaps are tracked in
+  [IEC 62443 Control Mapping open items](./IEC-62443-control-mapping.md#planned--open-items-phase-7)
+  and `.developer/TODO.md`.
+
+## Assumptions and Limits
+
+- This matrix is a baseline alignment artifact, not a certification outcome.
+- Formal external audit evidence (for example SoA, penetration test report,
+  control effectiveness sampling) remains out of scope for this document.
+
+## Related Artifacts
+
+- [Compliance README](./README.md)
+- [IEC 62443 Control Mapping](./IEC-62443-control-mapping.md)
+- [ADR-011: mTLS and Zero-Trust Service Mesh](../architecture/ADR-011-mtls-zero-trust-service-mesh.md)
+- [ADR-012: RBAC/ABAC Authorization Design](../architecture/ADR-012-rbac-abac-authorization-design.md)
+
+---
+
+_Last Updated: 2026-03-11 (Phase 7 baseline)_

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -9,12 +9,12 @@ NeuroLogix controls, policies, and evidence tracking.
 
 **Phase 7 — Active** · IEC 62443 control mapping baseline established.
 
-| Document | Status | Last Updated |
-|---|---|---|
-| [IEC 62443 Control Mapping](./IEC-62443-control-mapping.md) | ✅ Baseline + FR-5 allowlist/mTLS evidence | 2026-03-11 |
-| ISO 27001 / NIST CSF Alignment Matrix | 🔄 Planned (Phase 7) | — |
-| Audit Evidence Register | 🔄 Planned (Phase 7) | — |
-| Penetration Test Report | 🔄 Planned (Phase 7) | — |
+| Document                                                                         | Status                                     | Last Updated |
+| -------------------------------------------------------------------------------- | ------------------------------------------ | ------------ |
+| [IEC 62443 Control Mapping](./IEC-62443-control-mapping.md)                      | ✅ Baseline + FR-5 allowlist/mTLS evidence | 2026-03-11   |
+| [ISO 27001 / NIST CSF Alignment Matrix](./ISO27001-NIST-CSF-alignment-matrix.md) | ✅ Baseline established                    | 2026-03-11   |
+| Audit Evidence Register                                                          | 🔄 Planned (Phase 7)                       | —            |
+| Penetration Test Report                                                          | 🔄 Planned (Phase 7)                       | —            |
 
 ## IEC 62443 Compliance Summary
 
@@ -26,7 +26,8 @@ NeuroLogix targets **Security Level 2 (SL-2)** for Core, AI, and UI zones, and
 - **Planned (Phase 7 implementation work):** 9
 - **Not Applicable:** 4
 
-See [IEC-62443-control-mapping.md](./IEC-62443-control-mapping.md) for full detail.
+See [IEC-62443-control-mapping.md](./IEC-62443-control-mapping.md) for full
+detail.
 
 ## Architecture Evidence
 


### PR DESCRIPTION
## Summary
- add a new baseline alignment matrix at docs/compliance/ISO27001-NIST-CSF-alignment-matrix.md
- map ISO/IEC 27001:2022 Annex A domains to NIST CSF 2.0 categories with repository evidence links
- update compliance and developer indexes to reflect delivered Phase 7 baseline artifact

## Validation
- 
px prettier --check docs/compliance/ISO27001-NIST-CSF-alignment-matrix.md docs/compliance/README.md .developer/TODO.md
- 
pm run validate:doc-packets

Closes #194